### PR TITLE
Improve Fortress stack to allow stricter security groups

### DIFF
--- a/e3/aws/cfn/arch/security.py
+++ b/e3/aws/cfn/arch/security.py
@@ -1,0 +1,40 @@
+import requests
+from e3.aws.cfn.ec2.security import Ipv4EgressRule, SecurityGroup
+
+# This is the static address at which AWS publish the list of ip-ranges
+# used by its services.
+IP_RANGES_URL = "https://ip-ranges.amazonaws.com/ip-ranges.json"
+
+
+def amazon_security_group(name, vpc):
+    """Create a security group authorizing access to aws services.
+
+    :param vpc: vpc in which to create the group
+    :type vpc: VPC
+    :return: a security group
+    :rtype: SecurityGroup
+    """
+    ip_ranges = requests.get(IP_RANGES_URL).json()['prefixes']
+
+    # Retrieve first the complete list of ipv4 ip ranges for a given region
+    amazon_ip_ranges = {k['ip_prefix'] for k in ip_ranges
+                        if k['region'] == vpc.region and
+                        'ip_prefix' in k and
+                        k['service'] == 'AMAZON'}
+
+    # Sustract the list of ip ranges corresponding to EC2 instances
+    ec2_ip_ranges = {k['ip_prefix'] for k in ip_ranges
+                     if k['region'] == vpc.region and
+                     'ip_prefix' in k and
+                     k['service'] == 'EC2'}
+    amazon_ip_ranges -= ec2_ip_ranges
+
+    # Authorize https on the resulting list of ip ranges
+    # Note: the limit of rules per security group is set to 50 at AWS.
+    # In case the number of ip ranges returned by Amazon would be greater
+    # than that there would be need to split into several security groups
+    sg = SecurityGroup(name, vpc, description='Allow acces to amazon services')
+    for ip_range in amazon_ip_ranges:
+        sg.add_rule(Ipv4EgressRule('https', ip_range))
+
+    return sg

--- a/e3/aws/cfn/ec2/security.py
+++ b/e3/aws/cfn/ec2/security.py
@@ -97,6 +97,10 @@ class Ipv4EgressRule(EgressRule):
     RULE_TYPE = 'CidrIp'
 
 
+class PrefixListEgressRule(EgressRule):
+    RULE_TYPE = 'DestinationPrefixListId'
+
+
 class Ipv4IngressRule(IngressRule):
     RULE_TYPE = 'CidrIp'
 

--- a/tests/tests_e3_aws/cfn/arch/main_test.py
+++ b/tests/tests_e3_aws/cfn/arch/main_test.py
@@ -41,3 +41,37 @@ def test_create_fortress():
         f.add_private_server(AMI('ami-1234'), ['server1', 'server2'])
 
         assert f.body
+
+
+def test_create_fortress_no_bastion():
+    aws_env = AWSEnv(regions=['us-east-1'], stub=True)
+    with default_region('us-east-1'):
+        stub = aws_env.stub('ec2', region='us-east-1')
+        stub.add_response(
+            'describe_images',
+            {'Images': [{'ImageId': 'ami-1234',
+                         'RootDeviceName': '/dev/sda1',
+                         'Tags': []}]},
+            {'ImageIds': ANY})
+        stub.add_response(
+            'describe_images',
+            {'Images': [{'ImageId': 'ami-1234',
+                         'RootDeviceName': '/dev/sda1',
+                         'Tags': []}]},
+            {'ImageIds': ANY})
+        d = PolicyDocument().append(Allow(to='s3:GetObject',
+                                          on=['arn:aws:s3:::mybucket',
+                                              'arn:aws:s3:::mybucket/*']))
+        p = Policy('InternalPolicy', d)
+        f = Fortress('myfortress', bastion_ami=None,
+                     internal_server_policy=p)
+        f += Bucket('Bucket2')
+
+        # Allow access to mybucket through a s3 endpoint
+        f.private_subnet.add_bucket_access(['mybucket', f['Bucket2']])
+
+        # allow https
+        f.add_network_access('https')
+        f.add_private_server(AMI('ami-1234'), ['server1', 'server2'])
+
+        assert f.body


### PR DESCRIPTION
1- allow no bastion mode
2- add support for prefix lists in security groups
3- add support for amazon security group that allow access to AWS
   services on port 443