### PR TITLE
Get dict of amazon security groups

### DIFF
--- a/e3/aws/cfn/arch/security.py
+++ b/e3/aws/cfn/arch/security.py
@@ -38,3 +38,50 @@ def amazon_security_group(name, vpc):
         sg.add_rule(Ipv4EgressRule('https', ip_range))
 
     return sg
+
+
+def amazon_security_groups(name, vpc):
+    """Create a dict of security group authorizing access to aws services.
+
+    As the number of rules per security group is limited to 50,
+    we create blocks of 50 rules.
+
+    :param vpc: vpc in which to create the group
+    :type vpc: VPC
+    :return: a dict of security groups indexed by name
+    :rtype: dict(str, SecurityGroup)
+    """
+    ip_ranges = requests.get(IP_RANGES_URL).json()['prefixes']
+
+    # Retrieve first the complete list of ipv4 ip ranges for a given region
+    amazon_ip_ranges = {k['ip_prefix'] for k in ip_ranges
+                        if k['region'] == vpc.region and
+                        'ip_prefix' in k and
+                        k['service'] == 'AMAZON'}
+
+    # Sustract the list of ip ranges corresponding to EC2 instances
+    ec2_ip_ranges = {k['ip_prefix'] for k in ip_ranges
+                     if k['region'] == vpc.region and
+                     'ip_prefix' in k and
+                     k['service'] == 'EC2'}
+    amazon_ip_ranges -= ec2_ip_ranges
+
+    # Authorize https on the resulting list of ip ranges
+    sgs = {}
+    i = 0
+    limit = 50
+    sg_name = name + str(i)
+    sg = SecurityGroup(
+        sg_name,
+        vpc, description='Allow acces to amazon services')
+    sgs[sg_name] = sg
+    for ip_range in amazon_ip_ranges:
+        if len(sg.egress + sg.ingress) == limit:
+            i += 1
+            sg_name = name + str(i)
+            sg = SecurityGroup(
+                sg_name,
+                vpc, description='Allow acces to amazon services')
+            sgs[sg_name] = sg
+        sg.add_rule(Ipv4EgressRule('https', ip_range))
+    return sgs


### PR DESCRIPTION
Since rules per security group are limited to 50,
return a dict of groups containing 50 rules max each