### PR TITLE
Remove sort_keys argument in calls to yaml.Dumper.__init__

### DIFF
--- a/e3/aws/cfn/__init__.py
+++ b/e3/aws/cfn/__init__.py
@@ -128,8 +128,7 @@ class CFNYamlDumper(yaml.Dumper):
                  explicit_start=None,
                  explicit_end=None,
                  version=None,
-                 tags=None,
-                 sort_keys=True):
+                 tags=None):
         """Yaml dumper for cloud formation templates.
 
         See yaml.Dumper documentation.
@@ -147,8 +146,7 @@ class CFNYamlDumper(yaml.Dumper):
             explicit_start=explicit_start,
             explicit_end=explicit_end,
             version=version,
-            tags=tags,
-            sort_keys=sort_keys)
+            tags=tags)
 
         self.add_representer(GetAtt, getatt_representer)
         self.add_representer(Ref, ref_representer)


### PR DESCRIPTION
According to the yaml documentation, this argument doesn't exist.
Found while trying to run the deploy-repositories script.

(I'm not really sure the change is complete; but it allowed the script to complete instead of crashing)