### PR TITLE
Create script to set assume-role credentials

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,4 +10,8 @@ setup(
     author="AdaCore's Production Team",
     packages=find_packages(),
     install_requires=('botocore', 'pyyaml', 'e3-core'),
-    namespace_packages=['e3'])
+    namespace_packages=['e3'],
+    entry_points={
+        'console_scripts': [
+            'e3-aws-assume-role = e3.aws:assume_role_main'
+        ]})


### PR DESCRIPTION
$ e3-aws-assume-role arn:aws:iam::...
export AWS_ACCESS_KEY_ID=...
export AWS_SECRET_ACCESS_KEY=...
export AWS_SESSION_TOKEN=...

It can be used directly by running

$ eval `e3-aws-assume-role arn:aws:iam:...`
TN: S719-022