### PR TITLE
Add support of default disk size for EC2 instances

### DIFF
--- a/e3/aws/cfn/arch/__init__.py
+++ b/e3/aws/cfn/arch/__init__.py
@@ -314,7 +314,7 @@ class Fortress(Stack):
 
     def add_private_server(self, server_ami, names,
                            instance_type='t2.micro',
-                           disk_size=20,
+                           disk_size=None,
                            amazon_access=True,
                            persistent_eni=False):
         """Add servers in the private network.
@@ -326,8 +326,9 @@ class Fortress(Stack):
         :type names: list[str]
         :param instance_type: instance type (default: t2.micro)
         :type instance_type: str
-        :param disk_size: disk size of the instance in Go
-        :type disk_size: int
+        :param disk_size: disk size of the instance in Go or None to reuse the
+            AMI snapshot size
+        :type disk_size: int | None
         :param amazon_access: if True add a security group that allow access to
             amazon services. Default is True
         :type amazon_access: bool

--- a/e3/aws/cfn/ec2/__init__.py
+++ b/e3/aws/cfn/ec2/__init__.py
@@ -60,13 +60,14 @@ class EphemeralDisk(BlockDevice):
 class EBSDisk(BlockDevice):
     """EBS Disk."""
 
-    def __init__(self, device_name, size=20, encrypted=None):
+    def __init__(self, device_name, size=None, encrypted=None):
         """Initialize an EBS disk.
 
         :param device_name: name of the device associated with that disk
         :type device_name: str
-        :param size: disk size in Go (default: 20Go)
-        :type size: int
+        :param size: disk size in Go (default: 20Go). None can be used to
+            use the same size as the original AMI
+        :type size: int | None
         :param encrypted: if True encrypt the device, if None take the default
             (useful when device is created from a snapshot).
         :type encrypted: bool | None
@@ -84,9 +85,11 @@ class EBSDisk(BlockDevice):
         :rtype: dict
         """
         result = {"DeviceName": self.device_name,
-                  "Ebs": {"VolumeSize": str(self.size),
-                          "VolumeType": "gp2",
+                  "Ebs": {"VolumeType": "gp2",
                           "DeleteOnTermination": True}}
+        if self.size is not None:
+            result['Ebs']['VolumeSize'] = str(self.size)
+
         if self.encrypted is not None:
             result['Ebs']['Encrypted'] = self.encrypted
         return result


### PR DESCRIPTION
The default size is the size of the AMI snapshot