### PR TITLE
Promote use of e3-aws without AWS console need

### DIFF
--- a/tests/tests_e3_aws/cfn/main/main_test.py
+++ b/tests/tests_e3_aws/cfn/main/main_test.py
@@ -37,7 +37,7 @@ def test_cfn_main():
         stubber.add_response("describe_stacks", {}, {"StackName": "teststack"})
         with stubber:
             m = MyCFNMain(regions=["us-east-1"])
-            m.execute(args=["push"], aws_env=aws_env)
+            m.execute(args=["push", "--no-wait"], aws_env=aws_env)
 
 
 def test_cfn_main_s3():
@@ -83,4 +83,4 @@ def test_cfn_main_s3():
                     s3_bucket="superbucket",
                     s3_key="test_key",
                 )
-                m.execute(args=["push"], aws_env=aws_env)
+                m.execute(args=["push", "--no-wait"], aws_env=aws_env)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37-cov,checkstyle
+envlist = py38-cov,checkstyle
 
 [testenv]
 deps =
@@ -31,7 +31,6 @@ deps =
       black
       pyflakes>=1.2.3
       pydocstyle>=1.0.0
-      bandit
       pytest
       mock
       httpretty
@@ -45,11 +44,12 @@ commands =
 # Run bandit checks. Accept yaml.load(), pickle, and exec since this
 # is needed by e3. There is also e3.env.tmp_dir that returns the TMPDIR
 # environment variable. Don't check for that.
+basepython = python3
 deps =
       bandit
       safety
 commands =
-      bandit -r src -ll -ii -s B102,B108,B301,B506
+      bandit -r src -ll -ii -s B102,B108,B301,B322,B506
       safety check --full-report
 
 [pycodestyle]


### PR DESCRIPTION
Set --wait as a default when pushing a new stack, add --no-wait
to revert back to the previous behavior.

Remove hidden update --changeset option and ask by default whether
to apply the changeset. Add --no-apply switch to revert back to
the previous behavior.

TN: T622-032