### PR TITLE
When opening access to AWS services also open them for us-east-1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ install:
 script: tox
 matrix:
     include:
-        - python: 3.6
-          env: TOXENV=py36-cov-codecov,checkstyle,security
-          dist: trusty
+        - python: 3.8
+          env: TOXENV=py38-cov-codecov,checkstyle,security
+          dist: bionic
           sudo: false
           os: linux

--- a/src/e3/aws/cfn/arch/security.py
+++ b/src/e3/aws/cfn/arch/security.py
@@ -6,42 +6,6 @@ from e3.aws.cfn.ec2.security import Ipv4EgressRule, SecurityGroup
 IP_RANGES_URL = "https://ip-ranges.amazonaws.com/ip-ranges.json"
 
 
-def amazon_security_group(name, vpc):
-    """Create a security group authorizing access to aws services.
-
-    :param vpc: vpc in which to create the group
-    :type vpc: VPC
-    :return: a security group
-    :rtype: SecurityGroup
-    """
-    ip_ranges = requests.get(IP_RANGES_URL).json()["prefixes"]
-
-    # Retrieve first the complete list of ipv4 ip ranges for a given region
-    amazon_ip_ranges = {
-        k["ip_prefix"]
-        for k in ip_ranges
-        if k["region"] == vpc.region and "ip_prefix" in k and k["service"] == "AMAZON"
-    }
-
-    # Sustract the list of ip ranges corresponding to EC2 instances
-    ec2_ip_ranges = {
-        k["ip_prefix"]
-        for k in ip_ranges
-        if k["region"] == vpc.region and "ip_prefix" in k and k["service"] == "EC2"
-    }
-    amazon_ip_ranges -= ec2_ip_ranges
-
-    # Authorize https on the resulting list of ip ranges
-    # Note: the limit of rules per security group is set to 50 at AWS.
-    # In case the number of ip ranges returned by Amazon would be greater
-    # than that there would be need to split into several security groups
-    sg = SecurityGroup(name, vpc, description="Allow acces to amazon services")
-    for ip_range in amazon_ip_ranges:
-        sg.add_rule(Ipv4EgressRule("https", ip_range))
-
-    return sg
-
-
 def amazon_security_groups(name, vpc):
     """Create a dict of security group authorizing access to aws services.
 


### PR DESCRIPTION
Some services such as sts.amazonaws.com are only available in the us-east-1 region.

Also remove the unused function amazon_security_group, replaced by amazon_security_groups that take into account the limit of 50 rules per security group.