### PR TITLE
Enable access to GitHub git repositories

### DIFF
--- a/src/e3/aws/cfn/arch/security.py
+++ b/src/e3/aws/cfn/arch/security.py
@@ -48,7 +48,7 @@ def amazon_security_groups(name, vpc):
     i = 0
     limit = 50
     sg_name = name + str(i)
-    sg = SecurityGroup(sg_name, vpc, description="Allow acces to amazon services")
+    sg = SecurityGroup(sg_name, vpc, description="Allow access to amazon services")
     sgs[sg_name] = sg
     for ip_range in amazon_ip_ranges:
         if len(sg.egress + sg.ingress) == limit:
@@ -59,4 +59,38 @@ def amazon_security_groups(name, vpc):
             )
             sgs[sg_name] = sg
         sg.add_rule(Ipv4EgressRule("https", ip_range))
+    return sgs
+
+
+def github_security_groups(name, vpc, protocol):
+    """Create a dict of security group authorizing access to github services.
+
+    As the number of rules per security group is limited to 50,
+    we create blocks of 50 rules.
+
+    :param vpc: vpc in which to create the group
+    :type vpc: VPC
+    :param protocol: protocol to allow (https, ssh)
+    :type protocol: str
+    :return: a dict of security groups indexed by name
+    :rtype: dict(str, SecurityGroup)
+    """
+    ip_ranges = requests.get("https://api.github.com/meta").json()["git"]
+
+    # Authorize ssh on the resulting list of ip ranges
+    sgs = {}
+    i = 0
+    limit = 50
+    sg_name = name + str(i)
+    sg = SecurityGroup(sg_name, vpc, description="Allow access to github")
+    sgs[sg_name] = sg
+    for ip_range in ip_ranges:
+        if len(sg.egress + sg.ingress) == limit:
+            i += 1
+            sg_name = name + str(i)
+            sg = SecurityGroup(
+                sg_name, vpc, description=f"Allow access to GitHub {protocol}"
+            )
+            sgs[sg_name] = sg
+        sg.add_rule(Ipv4EgressRule(protocol, ip_range))
     return sgs

--- a/tests/tests_e3_aws/cfn/arch/main_test.py
+++ b/tests/tests_e3_aws/cfn/arch/main_test.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+import pytest
+
 from botocore.stub import ANY
 from e3.aws import AWSEnv, default_region
 from e3.aws.cfn.arch import Fortress
@@ -7,8 +9,47 @@ from e3.aws.cfn.iam import Allow, Policy, PolicyDocument
 from e3.aws.cfn.s3 import Bucket
 from e3.aws.ec2.ami import AMI
 
+AWS_IP_RANGES = {
+    "syncToken": "1600978876",
+    "createDate": "2020-09-24-20-21-16",
+    "prefixes": [
+        {
+            "ip_prefix": "3.5.140.0/22",
+            "region": "ap-northeast-2",
+            "service": "AMAZON",
+            "network_border_group": "ap-northeast-2",
+        },
+        {
+            "ip_prefix": "120.52.22.96/27",
+            "region": "GLOBAL",
+            "service": "AMAZON",
+            "network_border_group": "GLOBAL",
+        },
+        {
+            "ip_prefix": "150.222.81.0/24",
+            "region": "eu-west-1",
+            "service": "AMAZON",
+            "network_border_group": "eu-west-1",
+        },
+        {
+            "ip_prefix": "52.4.0.0/14",
+            "region": "us-east-1",
+            "service": "AMAZON",
+            "network_border_group": "us-east-1",
+        },
+    ],
+}
 
-def test_create_fortress():
+GITHUB_API_RANGE = {"git": ["127.0.0.1/24"]}
+
+
+@pytest.mark.parametrize("enable_github", [True, False])
+def test_create_fortress(enable_github, requests_mock):
+    if enable_github:
+        requests_mock.get("https://api.github.com/meta", json=GITHUB_API_RANGE)
+    requests_mock.get(
+        "https://ip-ranges.amazonaws.com/ip-ranges.json", json=AWS_IP_RANGES
+    )
     aws_env = AWSEnv(regions=["us-east-1"], stub=True)
     with default_region("us-east-1"):
         stub = aws_env.stub("ec2", region="us-east-1")
@@ -40,6 +81,7 @@ def test_create_fortress():
         f = Fortress(
             "myfortress",
             allow_ssh_from="0.0.0.0/0",
+            allow_github=enable_github,
             bastion_ami=AMI("ami-1234"),
             internal_server_policy=p,
         )
@@ -50,7 +92,9 @@ def test_create_fortress():
 
         # allow https
         f.add_network_access("https")
-        f.add_private_server(AMI("ami-1234"), ["server1", "server2"])
+        f.add_private_server(
+            AMI("ami-1234"), ["server1", "server2"], github_access=enable_github
+        )
 
         assert f.body
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ deps =
      e3-core
      pytest
      mock
+     requests_mock
      httpretty
      cov: pytest-cov
      codecov: codecov


### PR DESCRIPTION
Use api.github.com/meta to retrieve the list of ip ranges used
by GitHub to provide git access via ssh.

TN: T921-018