### PR TITLE
Review Security groups handling for private servers in Fortress.

### DIFF
--- a/tests/tests_e3_aws/cfn/arch/main_test.py
+++ b/tests/tests_e3_aws/cfn/arch/main_test.py
@@ -81,7 +81,6 @@ def test_create_fortress(enable_github, requests_mock):
         f = Fortress(
             "myfortress",
             allow_ssh_from="0.0.0.0/0",
-            allow_github=enable_github,
             bastion_ami=AMI("ami-1234"),
             internal_server_policy=p,
         )


### PR DESCRIPTION
* Remove unneed allow_github parameter in Fortress __init__.
* Delay computation of github and amazon groups
* Add ability to add additional custom groups