### PR TITLE
Add versioning_status argument to S3 buckets

### DIFF
--- a/tests/tests_e3_aws/troposphere/config/config_test.py
+++ b/tests/tests_e3_aws/troposphere/config/config_test.py
@@ -144,6 +144,7 @@ EXPECTED_RECORDER = {
                 "IgnorePublicAcls": "true",
                 "RestrictPublicBuckets": "true",
             },
+            "VersioningConfiguration": {"Status": "Enabled"},
         },
         "Type": "AWS::S3::Bucket",
     },

--- a/tests/tests_e3_aws/troposphere/s3/s3_test.py
+++ b/tests/tests_e3_aws/troposphere/s3/s3_test.py
@@ -20,6 +20,7 @@ EXPECTED_BUCKET = {
                 "IgnorePublicAcls": "true",
                 "RestrictPublicBuckets": "true",
             },
+            "VersioningConfiguration": {"Status": "Enabled"},
         },
         "Type": "AWS::S3::Bucket",
     },
@@ -80,6 +81,7 @@ EXPECTED_AWS_CONFIG_BUCKET = {
                 "IgnorePublicAcls": "true",
                 "RestrictPublicBuckets": "true",
             },
+            "VersioningConfiguration": {"Status": "Enabled"},
         },
         "Type": "AWS::S3::Bucket",
     },
@@ -151,7 +153,6 @@ EXPECTED_AWS_CONFIG_BUCKET = {
         "DependsOn": "TestBucket",
     },
 }
-
 
 EXPECTED_S3_ACCESS_MANAGED_POLICY = {
     "S3ManagedPolicy": {


### PR DESCRIPTION
A VersioningConfiguration can now be provided to enable multiple
versions of all objects in a bucket.