### PR TITLE
Remove B322 of bandit list of test IDs to skip

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -51,7 +51,7 @@ deps =
       bandit
       safety
 commands =
-      bandit -r src -ll -ii -s B102,B108,B301,B322,B506
+      bandit -r src -ll -ii -s B102,B108,B301,B506
       safety check --full-report
 
 [pycodestyle]


### PR DESCRIPTION
The test was removed from latest bandit version. See https://github.com/
PyCQA/bandit/commit/8295ded4101610c6dc7224c261d80accb4775f1e