### PR TITLE
Make managed policy depends on iam entities.

### DIFF
--- a/src/e3/aws/troposphere/s3/managed_policy.py
+++ b/src/e3/aws/troposphere/s3/managed_policy.py
@@ -28,9 +28,9 @@ class S3AccessManagedPolicy(ManagedPolicy):
     name: str
     buckets: List[str] = field(default_factory=list)
     action: List[str] = field(default_factory=list)
-    users: Optional[List[str]] = None
-    groups: Optional[List[str]] = None
-    roles: Optional[List[str]] = None
+    users: Optional[List[str]] = field(default_factory=list)
+    groups: Optional[List[str]] = field(default_factory=list)
+    roles: Optional[List[str]] = field(default_factory=list)
     description: str = "S3 Bucket access managed policy"
 
     @property

--- a/tests/tests_e3_aws/troposphere/s3/s3_test.py
+++ b/tests/tests_e3_aws/troposphere/s3/s3_test.py
@@ -156,6 +156,7 @@ EXPECTED_AWS_CONFIG_BUCKET = {
 
 EXPECTED_S3_ACCESS_MANAGED_POLICY = {
     "S3ManagedPolicy": {
+        "DependsOn": ["TestRole"],
         "Properties": {
             "Description": "S3 Bucket access managed policy",
             "ManagedPolicyName": "S3ManagedPolicy",


### PR DESCRIPTION
Errors are raised when deploying cloudformation stacks if managed policy
are created before the iam entities they are attached too. The DependsOn
attribute force the iam entities to be created before policies.