### PR TITLE
Remove ACL_Control setting from S3 Bucket.

### DIFF
--- a/src/e3/aws/troposphere/s3/bucket.py
+++ b/src/e3/aws/troposphere/s3/bucket.py
@@ -31,7 +31,6 @@ class Bucket(Construct):
 
     name: str
     enable_versioning: bool = True
-    access_control: str = field(default="Private", init=False)
     bucket_encryption: Dict[str, List[Dict[str, Dict[str, str]]]] = field(
         default_factory=lambda: {
             "ServerSideEncryptionConfiguration": [
@@ -73,7 +72,6 @@ class Bucket(Construct):
             s3.Bucket(
                 name_to_id(self.name),
                 BucketName=self.name,
-                AccessControl=self.access_control,
                 BucketEncryption=s3.BucketEncryption.from_dict(
                     "DefautBucketEncryption", self.bucket_encryption
                 ),

--- a/tests/tests_e3_aws/troposphere/config/config_test.py
+++ b/tests/tests_e3_aws/troposphere/config/config_test.py
@@ -132,7 +132,6 @@ EXPECTED_RECORDER = {
     "ConfigTestBucket": {
         "Properties": {
             "BucketName": "config-test-bucket",
-            "AccessControl": "Private",
             "BucketEncryption": {
                 "ServerSideEncryptionConfiguration": [
                     {"ServerSideEncryptionByDefault": {"SSEAlgorithm": "AES256"}}

--- a/tests/tests_e3_aws/troposphere/s3/s3_test.py
+++ b/tests/tests_e3_aws/troposphere/s3/s3_test.py
@@ -8,7 +8,6 @@ EXPECTED_BUCKET = {
     "TestBucket": {
         "Properties": {
             "BucketName": "test-bucket",
-            "AccessControl": "Private",
             "BucketEncryption": {
                 "ServerSideEncryptionConfiguration": [
                     {"ServerSideEncryptionByDefault": {"SSEAlgorithm": "AES256"}}
@@ -69,7 +68,6 @@ EXPECTED_AWS_CONFIG_BUCKET = {
     "TestBucket": {
         "Properties": {
             "BucketName": "test-bucket",
-            "AccessControl": "Private",
             "BucketEncryption": {
                 "ServerSideEncryptionConfiguration": [
                     {"ServerSideEncryptionByDefault": {"SSEAlgorithm": "AES256"}}


### PR DESCRIPTION
ACL are not needed. Policy document provides finer control on
permissions.