### PR TITLE
Shrink Fortress public subnet range

### DIFF
--- a/src/e3/aws/cfn/arch/__init__.py
+++ b/src/e3/aws/cfn/arch/__init__.py
@@ -243,7 +243,7 @@ class Fortress(Stack):
         description=None,
         vpc_cidr_block="10.10.0.0/16",
         private_cidr_block="10.10.0.0/17",
-        public_cidr_block="10.10.128.0/17",
+        public_cidr_block="10.10.128.0/18",
     ):
         """Create a VPC Fortress.
 


### PR DESCRIPTION
This is to free some IPS for an incoming subnet for VPC endpoint network
interfaces.