### PR TITLE
Add SecretsManager access through VPC endpoint

### DIFF
--- a/src/e3/aws/cfn/__init__.py
+++ b/src/e3/aws/cfn/__init__.py
@@ -194,19 +194,17 @@ class CFNYamlDumper(yaml.Dumper):
         return True
 
 
-class Resource(object):
+class Resource:
     """A CloudFormation resource."""
 
     # List of valid attribute names
     ATTRIBUTES: Iterable[str] = ()
 
-    def __init__(self, name, kind):
+    def __init__(self, name: str, kind: AWSType):
         """Initialize a resource.
 
         :param name: name of the resource (alphanumeric)
-        :type name: str
         :param kind: resource kind
-        :type kind: e3.aws.cfn.types.AWSType
         """
         assert isinstance(kind, AWSType), (
             "resource kind should be an AWSType: found %s" % kind
@@ -222,7 +220,7 @@ class Resource(object):
             self.region = Env().aws_env.default_region
         else:
             self.region = "invalid-region"
-        self.metadata = {}
+        self.metadata: dict = {}
 
     def getatt(self, name):
         """Return an attribute reference.
@@ -264,7 +262,7 @@ class Resource(object):
         """
         result = {"Type": self.kind.value, "Properties": self.properties}
         if self.depends is not None:
-            result["DependsOn"] = self.depends
+            result["DependsOn"] = self.depends  # type: ignore
         if self.metadata:
             result["Metadata"] = self.metadata
         return result
@@ -463,14 +461,12 @@ class Stack(object):
         self.uuid = str(uuid.uuid1(clock_seq=int(1000 * time.time())))
         self.latest_read_event: Optional[StackEvent] = None
 
-    def add(self, element):
+    def add(self, element: Stack | Resource) -> Stack:
         """Add a resource or merge a stack.
 
         :param element: if a resource add the resource to the stack. If a stack
             merge its resources into the current stack.
-        :type element: Stack | Resources
         :return: the current stack
-        :rtype: Stack
         """
         assert isinstance(element, Resource) or isinstance(element, Stack), (
             "a resource or a stack is expected. got %s" % element

--- a/src/e3/aws/cfn/arch/__init__.py
+++ b/src/e3/aws/cfn/arch/__init__.py
@@ -17,6 +17,7 @@ from e3.aws.cfn.ec2 import (
     SubnetRouteTableAssociation,
     VPC,
     VPCEndpoint,
+    VPCInterfaceEndpoint,
     VPCGatewayAttachment,
 )
 from e3.aws.cfn.ec2.security import (
@@ -243,13 +244,15 @@ class Fortress(Stack):
         description=None,
         vpc_cidr_block="10.10.0.0/16",
         private_cidr_block="10.10.0.0/17",
-        public_cidr_block="10.10.128.0/17",
+        public_cidr_block="10.10.128.0/18",
+        aws_endpoints_cidr_block="10.10.192.0/18",
     ):
         """Create a VPC Fortress.
 
         This create a vpc with a public and a private subnet. Servers in the
-        private subnet are only accessible through a bastion machine declare
-        in the public subnet.
+        private subnet are only accessible through a bastion machine declared
+        in the public subnet. An additional subnet is created to host AWS
+        services endpoints network interfaces.
 
         :param name: stack name
         :type name: str
@@ -270,10 +273,13 @@ class Fortress(Stack):
         :param public_cidr_block: ip ranges (subset of vpc_cidr_block) used
             for public subnet
         :type public_cidr_block: str
+        :param aws_endpoints_cidr_block: ip ranges (subset of vpc_cidr_block) used
+            for aws endpoints
+        :type aws_endpoints_cidr_block: str
         """
         super().__init__(name, description)
 
-        # Create VPC along with the two subnets
+        # Create VPC along with the three subnets
         self.add(VPCStack(self.name + "VPC", vpc_cidr_block))
         self.vpc.add_subnet(
             self.name + "PublicNet", public_cidr_block, is_public=True, use_nat=True
@@ -281,6 +287,7 @@ class Fortress(Stack):
         self.vpc.add_subnet(
             self.name + "PrivateNet", private_cidr_block, nat_to=self.name + "PublicNet"
         )
+        self.vpc.add_subnet(self.name + "AWSEndpointsNet", aws_endpoints_cidr_block)
 
         self.amazon_groups = {}
         self.github_groups = {}
@@ -312,8 +319,14 @@ class Fortress(Stack):
                 SecurityGroup(
                     self.name + "InternalSG",
                     self.vpc.vpc,
-                    description="Allow ssh inside VPC",
-                    rules=[Ipv4IngressRule("ssh", self.public_subnet.cidr_block)],
+                    description=(
+                        "Allow ssh inside VPC and allow https "
+                        "to VPC endpoints subnet"
+                    ),
+                    rules=[
+                        Ipv4IngressRule("ssh", self.public_subnet.cidr_block),
+                        Ipv4EgressRule("https", self.aws_endpoints_subnet.cidr_block),
+                    ],
                 )
             )
         else:
@@ -322,9 +335,25 @@ class Fortress(Stack):
                 SecurityGroup(
                     self.name + "InternalSG",
                     self.vpc.vpc,
-                    description="Do not allow ssh inside VPC",
+                    description=(
+                        "Do not allow ssh inside VPC but allow https "
+                        "to the VPC endpoints subnet."
+                    ),
+                    rules=[
+                        Ipv4EgressRule("https", self.aws_endpoints_subnet.cidr_block)
+                    ],
                 )
             )
+
+        # Create security group for endpoints
+        self.add(
+            SecurityGroup(
+                self.name + "InterfaceEndpointsSG",
+                self.vpc.vpc,
+                description=("Allow https from the private subnet"),
+                rules=[Ipv4IngressRule("https", self.private_subnet.cidr_block)],
+            )
+        )
 
         ir = InstanceRole(self.name + "PrivServerInstanceRole")
         ir.add_policy(internal_server_policy)
@@ -338,6 +367,37 @@ class Fortress(Stack):
         :rtype: str
         """
         return self[self.name + "VPC"].region
+
+    def add_secret_access(self, secret_arn):
+        """Give read access to a given secret.
+
+        :param secret_name: arn identifying the secret to give access to
+        :type secret_name: str
+        """
+        endpoint_name = f"{self.name}SecretsManagerEndPoint"
+        if endpoint_name not in self:
+            self.add(
+                VPCInterfaceEndpoint(
+                    name=endpoint_name,
+                    service="secretsmanager",
+                    vpc=self.vpc,
+                    subnet=self.aws_endpoints_subnet.subnet,
+                    policy_document=PolicyDocument(),
+                    security_group=self.aws_endpoints_security_group,
+                )
+            )
+        self.secretsmanager_endpoint.policy_document.append(
+            Allow(
+                to=[
+                    "secretsmanager:GetResourcePolicy",
+                    "secretsmanager:GetSecretValue",
+                    "secretsmanager:DescribeSecret",
+                    "secretsmanager:ListSecretVersionIds",
+                ],
+                on=[secret_arn],
+                apply_to=Principal(PrincipalKind.EVERYONE),
+            )
+        )
 
     def add_network_access(
         self,
@@ -503,6 +563,22 @@ class Fortress(Stack):
     @property
     def private_subnet(self):
         return self.vpc[self.name + "PrivateNet"]
+
+    @property
+    def aws_endpoints_subnet(self):
+        return self.vpc[self.name + "AWSEndpointsNet"]
+
+    @property
+    def internal_security_group(self):
+        return self[self.name + "InternalSG"]
+
+    @property
+    def aws_endpoints_security_group(self):
+        return self[self.name + "InterfaceEndpointsSG"]
+
+    @property
+    def secretsmanager_endpoint(self):
+        return self[self.name + "SecretsManagerEndPoint"]
 
     @property
     def public_subnet(self):

--- a/src/e3/aws/cfn/ec2/security.py
+++ b/src/e3/aws/cfn/ec2/security.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import abc
 from typing import TYPE_CHECKING
-from e3.aws.cfn import AWSType, Resource
+from e3.aws.cfn import AWSType, GetAtt, Resource
 from e3.aws.cfn.ec2 import VPC
 
 if TYPE_CHECKING:
@@ -138,6 +138,11 @@ class SecurityGroup(Resource):
             self.egress.append(rule)
         else:
             raise AssertionError("a security group rule is expected")
+
+    @property
+    def group_id(self):
+        """Return SecurityGroup GroupId."""
+        return GetAtt(self.name, "GroupId")
 
     @property
     def properties(self):

--- a/src/e3/aws/cfn/iam.py
+++ b/src/e3/aws/cfn/iam.py
@@ -184,7 +184,7 @@ class Deny(Statement):
     EFFECT = "Deny"
 
 
-class PolicyDocument(object):
+class PolicyDocument:
     """IAM Policy Document."""
 
     def __init__(self):

--- a/tests/tests_e3_aws/cfn/arch/main_test.py
+++ b/tests/tests_e3_aws/cfn/arch/main_test.py
@@ -89,6 +89,9 @@ def test_create_fortress(enable_github, requests_mock):
         # Allow access to mybucket through a s3 endpoint
         f.private_subnet.add_bucket_access(["mybucket", f["Bucket2"]])
 
+        # Allow access to a secret throught a secretsmanager endpoint
+        f.add_secret_access("arn_secret")
+
         # allow https
         f.add_network_access("https")
         f.add_private_server(
@@ -132,6 +135,9 @@ def test_create_fortress_no_bastion():
 
         # Allow access to mybucket through a s3 endpoint
         f.private_subnet.add_bucket_access(["mybucket", f["Bucket2"]])
+
+        # Allow access to a secret throught a secretsmanager endpoint
+        f.add_secret_access("arn_secret")
 
         # allow https
         f.add_network_access("https")


### PR DESCRIPTION
SecretsManager service IP is listed in AWS IP address ranges but not
allowed to be reached as it is in the range of EC2 service. A VPC
endpoint is thus needed even when authorizing access to aws services
with amazon_securtity_group.