### PR TITLE
Fix lambda VPC endpoint

### DIFF
--- a/src/e3/aws/cfn/arch/__init__.py
+++ b/src/e3/aws/cfn/arch/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from itertools import chain
 from typing import TYPE_CHECKING
 
 from e3.aws.cfn import Stack, Join
@@ -389,7 +390,9 @@ class Fortress(Stack):
         self.lambda_endpoint.policy_document.append(
             Allow(
                 to=["lambda:InvokeFunction"],
-                on=lambda_arns,
+                on=chain.from_iterable(
+                    ((lambda_arn, lambda_arn + ":*") for lambda_arn in lambda_arns)
+                ),
                 apply_to=Principal(PrincipalKind.EVERYONE),
             )
         )


### PR DESCRIPTION
Both the qualified and the unqualified function ARN must be included in
the endpoint policy resource allowing lambda:InvokeFunction.

Part of U830-009