### PR TITLE
Add cloudfront S3WebsiteDistribution construct

### DIFF
--- a/src/e3/aws/troposphere/cloudfront/__init__.py
+++ b/src/e3/aws/troposphere/cloudfront/__init__.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+import os
+from typing import TYPE_CHECKING
+
+
+from troposphere import AccountId, cloudfront, GetAtt, Join, route53, Ref, Sub
+
+from e3.aws import name_to_id
+from e3.aws.troposphere import Construct
+from e3.aws.troposphere.awslambda import Function
+from e3.aws.troposphere.iam.managed_policy import ManagedPolicy
+from e3.aws.troposphere.iam.policy_statement import Allow, Trust
+from e3.aws.troposphere.iam.role import Role
+from e3.aws.troposphere.s3.bucket import Bucket
+from e3.aws.troposphere.sns import Topic
+
+if TYPE_CHECKING:
+    from typing import Optional, Tuple
+    from troposphere import AWSObject
+    from e3.aws.troposphere import Stack
+
+
+class S3WebsiteDistribution(Construct):
+    """Set a Cloudfront distribution in front of a website hosted in S3.
+
+    It also provides a lambda invalidating cloudfront cache when s3 objects
+    are updated.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        aliases: list[str],
+        bucket_name: str,
+        certificate_arn: str,
+        default_ttl: int = 86400,
+        lambda_edge_function_arns: Optional[list[str]] = None,
+        root_object: str = "index.html",
+        r53_route_from: Optional[list[Tuple[str, str]]] = None,
+    ):
+        """Initialize a S3WebsiteCFDistribution.
+
+        :param name: function name
+        :param aliases: CNAMEs (alternate domain names), if any, for this
+            distribution.
+        :param bucket_name: name of the bucket to create to host the website
+        :param certificate_arn: Amazon Resource Name (ARN) of the ACM
+            certificate for aliases. Cloudfront only supports ceritificates
+            stored in us-east-1.
+        :param default_ttl: The default amount of time, in seconds, that you
+            want objects to stay in the CloudFront cache before CloudFront sends
+            another request to the origin to see if the object has been updated
+        :param lambda_edge_function_arns: ARNs of Lambda@Edge functions to
+            associate with the cloudfront distribution default cache behaviour
+        :param root_object: The object that you want CloudFront to request from
+            your origin
+        :param r53_route_from: list of (hosted_zone_id, domain_id) for which to
+            create route53 records
+        """
+        self.name = name
+        self.aliases = aliases
+        self.bucket = Bucket(name=bucket_name)
+        self.certificate_arn = certificate_arn
+        self.default_ttl = default_ttl
+        self.lambda_edge_function_arns = lambda_edge_function_arns
+        self.root_object = root_object
+        self.r53_route_from = r53_route_from
+        self._origin_access_identity = None
+        self._cache_policy = None
+
+    def add_oai_access_to_bucket(self) -> None:
+        """Add policy granting cloudfront OAI read access to the bucket."""
+        cf_principal = {
+            "CanonicalUser": GetAtt(self.origin_access_identity, "S3CanonicalUserId")
+        }
+        self.bucket.policy_statements.extend(
+            [
+                Allow(
+                    action="s3:GetObject",
+                    resource=self.bucket.all_objects_arn,
+                    principal=cf_principal,
+                ),
+                Allow(
+                    action="s3:ListBucket",
+                    resource=self.bucket.arn,
+                    principal=cf_principal,
+                ),
+            ]
+        )
+
+    @property
+    def cache_policy(self) -> cloudfront.CachePolicy:
+        """Return cloudfront distribution cache policy."""
+        if self._cache_policy is None:
+            forwarded_to_origin = cloudfront.ParametersInCacheKeyAndForwardedToOrigin(
+                CookiesConfig=cloudfront.CacheCookiesConfig(CookieBehavior="none"),
+                EnableAcceptEncodingBrotli="true",
+                EnableAcceptEncodingGzip="true",
+                HeadersConfig=cloudfront.CacheHeadersConfig(HeaderBehavior="none"),
+                QueryStringsConfig=cloudfront.CacheQueryStringsConfig(
+                    QueryStringBehavior="none"
+                ),
+            )
+            self._cache_policy = cloudfront.CachePolicy(
+                name_to_id(f"{self.name}-cloudfront-cache-policy"),
+                CachePolicyConfig=cloudfront.CachePolicyConfig(
+                    Comment=f"{self.name} s3 website cloudfront cache policy",
+                    DefaultTTL=self.default_ttl,
+                    MaxTTL=31536000,
+                    MinTTL=1,
+                    Name="s3-cache-policy",
+                    ParametersInCacheKeyAndForwardedToOrigin=forwarded_to_origin,
+                ),
+            )
+        return self._cache_policy
+
+    @property
+    def distribution(self) -> cloudfront.Distribution:
+        """Return cloudfront distribution with bucket as origin."""
+        origin = cloudfront.Origin(
+            S3OriginConfig=cloudfront.S3OriginConfig(
+                OriginAccessIdentity=Join(
+                    "",
+                    [
+                        "origin-access-identity/cloudfront/",
+                        Ref(self.origin_access_identity),
+                    ],
+                )
+            ),
+            DomainName=f"{self.bucket.name}.s3.amazonaws.com",
+            Id="S3Origin",
+        )
+        cache_params = {
+            "AllowedMethods": ["GET", "HEAD", "OPTIONS"],
+            "CachePolicyId": Ref(self.cache_policy),
+            "TargetOriginId": "S3Origin",
+            "ViewerProtocolPolicy": "redirect-to-https",
+        }
+        if self.lambda_edge_function_arns:
+            cache_params["LambdaFunctionAssociations"] = [
+                cloudfront.LambdaFunctionAssociation(
+                    EventType="viewer-request", LambdaFunctionARN=lambda_arn
+                )
+                for lambda_arn in self.lambda_edge_function_arns
+            ]
+
+        default_cache_behavior = cloudfront.DefaultCacheBehavior(**cache_params)
+        return cloudfront.Distribution(
+            name_to_id(self.name),
+            DistributionConfig=cloudfront.DistributionConfig(
+                Aliases=self.aliases,
+                DefaultRootObject=self.root_object,
+                DefaultCacheBehavior=default_cache_behavior,
+                Enabled="True",
+                HttpVersion="http2",
+                Origins=[origin],
+                ViewerCertificate=cloudfront.ViewerCertificate(
+                    AcmCertificateArn=self.certificate_arn, SslSupportMethod="sni-only"
+                ),
+            ),
+        )
+
+    @property
+    def origin_access_identity(self) -> cloudfront.CloudFrontOriginAccessIdentity:
+        """Return cloudformation access identity.
+
+        It is needed to be used as principal for s3 bucket access policy.
+        """
+        if self._origin_access_identity is None:
+            cf_oai_config = cloudfront.CloudFrontOriginAccessIdentityConfig(
+                Comment=f"{self.name} Cloudfront origin access identity"
+            )
+            self._origin_access_identity = cloudfront.CloudFrontOriginAccessIdentity(
+                name_to_id(f"{self.name}-cloudfront-oai"),
+                CloudFrontOriginAccessIdentityConfig=cf_oai_config,
+            )
+        return self._origin_access_identity
+
+    def add_cache_invalidation(self, stack: Stack) -> list[AWSObject]:
+        """Return resources invalidating cache when objects are pushed to s3.
+
+        A lambda is called at each s3 object update to invalidate cloudformation
+        cache for the updated object.
+        """
+        lambda_name = f"{self.name}-cache-invalidation-lambda"
+        lambda_policy = ManagedPolicy(
+            name=f"{lambda_name}-policy",
+            description=f"managed policy used by {lambda_name}",
+            path=f"/{stack.name}/",
+            statements=[
+                Allow(
+                    action=["cloudfront:CreateInvalidation"],
+                    resource=Join(
+                        "",
+                        ["arn:aws:cloudfront::", AccountId, ":distribution ", self.id],
+                    ),
+                )
+            ],
+        )
+        lambda_role = Role(
+            name=f"{lambda_name}-role",
+            description=f"role assumed by {lambda_name}",
+            path=f"/{stack.name}/",
+            trust=Trust(services=["lambda"]),
+            managed_policy_arns=[lambda_policy.arn],
+        )
+
+        # Get first part of invalidation lambda code from a file
+        with open(
+            os.path.join(
+                os.path.dirname(os.path.abspath(__file__)),
+                "data",
+                "lambda_invalidate_head.py",
+            )
+        ) as lf:
+            lambda_code = lf.read().splitlines()
+
+        # Complete it with the part depending on the distribution id
+        lambda_code.extend(
+            [
+                "    client.create_invalidation(",
+                Sub(
+                    "        DistributionId='${distribution_id}',",
+                    distribution_id=self.id,
+                ),
+                "        InvalidationBatch={",
+                "            'Paths': {'Quantity': 1, 'Items': path},",
+                "            'CallerReference': str(time.time()),",
+                "        },",
+                "    )",
+            ]
+        )
+        lambda_function = Function(
+            name_to_id(lambda_name),
+            description=(
+                f"lambda invalidating cloudfront cache when "
+                f"{self.bucket.name} objects are updated"
+            ),
+            handler="invalidate.handler",
+            role=lambda_role,
+            code_zipfile=Join("\n", lambda_code),
+            runtime="python3.9",
+        )
+
+        sns_topic = Topic(name=f"{self.name}-invalidation-topic")
+        sns_topic.add_lambda_subscription(
+            function=lambda_function,
+            delivery_policy={"throttlePolicy": {"maxReceivesPerSecond": 10}},
+        )
+        # Trigger the invalidation when a file is updated
+        self.bucket.add_notification_configuration(
+            event="s3:ObjectCreated:*", target=sns_topic, permission_suffix=self.name
+        )
+
+        result = [
+            resource
+            for construct in (lambda_policy, lambda_role, lambda_function, sns_topic)
+            for resource in construct.resources(stack)
+        ]
+        return result
+
+    @property
+    def domain_name(self) -> GetAtt:
+        """Return cloudfront distribution domain name."""
+        return GetAtt(name_to_id(self.name), "DomainName")
+
+    @property
+    def id(self) -> Ref:
+        """Return cloudfront distribution id."""
+        return Ref(name_to_id(self.name))
+
+    def resources(self, stack: Stack) -> list[AWSObject]:
+        """Return list of AWSObject associated with the construct."""
+        # Add bucket policy granting read access to te cloudfront distribution
+        self.add_oai_access_to_bucket()
+
+        result = [
+            *self.bucket.resources(stack),
+            self.cache_policy,
+            self.distribution,
+            self.origin_access_identity,
+        ]
+
+        # Add a lambda invalidating cloudfront cache when bucket objects are modified
+        result.extend(self.add_cache_invalidation(stack))
+
+        # Add route53 records if needed
+        if self.r53_route_from:
+            for zone_id, domain in self.r53_route_from:
+                result.append(
+                    route53.RecordSetType(
+                        name_to_id(f"{self.name}-{domain}-r53-rset"),
+                        AliasTarget=route53.AliasTarget(
+                            DNSName=self.domain_name,
+                            # Z2FDTNDATAQYW2 is always the hosted zone ID when you
+                            # create an alias record that routes traffic to a
+                            # CloudFront distribution
+                            HostedZoneId="Z2FDTNDATAQYW2",
+                        ),
+                        Name=domain,
+                        HostedZoneId=zone_id,
+                        Type="A",
+                    )
+                )
+        return result

--- a/src/e3/aws/troposphere/cloudfront/data/lambda_invalidate_head.py
+++ b/src/e3/aws/troposphere/cloudfront/data/lambda_invalidate_head.py
@@ -1,0 +1,12 @@
+import boto3
+import time  # noqa: F401
+
+
+def handler(event, context):
+    path = []
+    client = boto3.client("cloudfront")  # noqa: F841
+    for items in event["Records"]:
+        if items["s3"]["object"]["key"] == "index.html":
+            path.append("/")
+        else:
+            path.append("/" + items["s3"]["object"]["key"])

--- a/tests/tests_e3_aws/troposphere/cloudfront_test.py
+++ b/tests/tests_e3_aws/troposphere/cloudfront_test.py
@@ -1,0 +1,30 @@
+"""Provide Cloudformation construct tests."""
+from __future__ import annotations
+import json
+import os
+
+from e3.aws.troposphere import Stack
+from e3.aws.troposphere.cloudfront import S3WebsiteDistribution
+
+
+TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def test_s3_website_distribution(stack: Stack) -> None:
+    """Test Cloudfront S3WebsiteDistribution construct."""
+    stack.add(
+        S3WebsiteDistribution(
+            name="test-s3w-dist",
+            aliases=["test.s3w.com"],
+            bucket_name="host-bucket",
+            certificate_arn="acm_arn",
+            default_ttl=360,
+            lambda_edge_function_arns=["lamba_arn"],
+            r53_route_from=[("hosted_zone_id", "test.s3w.com")],
+        )
+    )
+
+    with open(os.path.join(TEST_DIR, "s3websitedistribution.json")) as fd:
+        expected_template = json.load(fd)
+
+    assert stack.export()["Resources"] == expected_template

--- a/tests/tests_e3_aws/troposphere/s3websitedistribution.json
+++ b/tests/tests_e3_aws/troposphere/s3websitedistribution.json
@@ -1,0 +1,368 @@
+{
+    "HostBucket": {
+        "Properties": {
+            "BucketName": "host-bucket",
+            "BucketEncryption": {
+                "ServerSideEncryptionConfiguration": [
+                    {
+                        "ServerSideEncryptionByDefault": {
+                            "SSEAlgorithm": "AES256"
+                        }
+                    }
+                ]
+            },
+            "PublicAccessBlockConfiguration": {
+                "BlockPublicAcls": true,
+                "BlockPublicPolicy": true,
+                "IgnorePublicAcls": true,
+                "RestrictPublicBuckets": true
+            },
+            "VersioningConfiguration": {
+                "Status": "Enabled"
+            }
+        },
+        "Type": "AWS::S3::Bucket"
+    },
+    "HostBucketPolicy": {
+        "Properties": {
+            "Bucket": {
+                "Ref": "HostBucket"
+            },
+            "PolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Deny",
+                        "Principal": {
+                            "AWS": "*"
+                        },
+                        "Action": "s3:*",
+                        "Resource": "arn:aws:s3:::host-bucket/*",
+                        "Condition": {
+                            "Bool": {
+                                "aws:SecureTransport": "false"
+                            }
+                        }
+                    },
+                    {
+                        "Effect": "Deny",
+                        "Principal": {
+                            "AWS": "*"
+                        },
+                        "Action": "s3:PutObject",
+                        "Resource": "arn:aws:s3:::host-bucket/*",
+                        "Condition": {
+                            "StringNotEquals": {
+                                "s3:x-amz-server-side-encryption": "AES256"
+                            }
+                        }
+                    },
+                    {
+                        "Effect": "Deny",
+                        "Principal": {
+                            "AWS": "*"
+                        },
+                        "Action": "s3:PutObject",
+                        "Resource": "arn:aws:s3:::host-bucket/*",
+                        "Condition": {
+                            "Null": {
+                                "s3:x-amz-server-side-encryption": "true"
+                            }
+                        }
+                    },
+                    {
+                        "Effect": "Allow",
+                        "Principal": {
+                            "CanonicalUser": {
+                                "Fn::GetAtt": [
+                                    "TestS3wDistCloudfrontOai",
+                                    "S3CanonicalUserId"
+                                ]
+                            }
+                        },
+                        "Action": "s3:GetObject",
+                        "Resource": "arn:aws:s3:::host-bucket/*"
+                    },
+                    {
+                        "Effect": "Allow",
+                        "Principal": {
+                            "CanonicalUser": {
+                                "Fn::GetAtt": [
+                                    "TestS3wDistCloudfrontOai",
+                                    "S3CanonicalUserId"
+                                ]
+                            }
+                        },
+                        "Action": "s3:ListBucket",
+                        "Resource": "arn:aws:s3:::host-bucket"
+                    }
+                ]
+            }
+        },
+        "Type": "AWS::S3::BucketPolicy"
+    },
+    "TestS3wDistCloudfrontCachePolicy": {
+        "Properties": {
+            "CachePolicyConfig": {
+                "Comment": "test-s3w-dist s3 website cloudfront cache policy",
+                "DefaultTTL": 360,
+                "MaxTTL": 31536000,
+                "MinTTL": 1,
+                "Name": "s3-cache-policy",
+                "ParametersInCacheKeyAndForwardedToOrigin": {
+                    "CookiesConfig": {
+                        "CookieBehavior": "none"
+                    },
+                    "EnableAcceptEncodingBrotli": true,
+                    "EnableAcceptEncodingGzip": true,
+                    "HeadersConfig": {
+                        "HeaderBehavior": "none"
+                    },
+                    "QueryStringsConfig": {
+                        "QueryStringBehavior": "none"
+                    }
+                }
+            }
+        },
+        "Type": "AWS::CloudFront::CachePolicy"
+    },
+    "TestS3wDist": {
+        "Properties": {
+            "DistributionConfig": {
+                "Aliases": [
+                    "test.s3w.com"
+                ],
+                "DefaultRootObject": "index.html",
+                "DefaultCacheBehavior": {
+                    "AllowedMethods": [
+                        "GET",
+                        "HEAD",
+                        "OPTIONS"
+                    ],
+                    "CachePolicyId": {
+                        "Ref": "TestS3wDistCloudfrontCachePolicy"
+                    },
+                    "TargetOriginId": "S3Origin",
+                    "ViewerProtocolPolicy": "redirect-to-https",
+                    "LambdaFunctionAssociations": [
+                        {
+                            "EventType": "viewer-request",
+                            "LambdaFunctionARN": "lamba_arn"
+                        }
+                    ]
+                },
+                "Enabled": true,
+                "HttpVersion": "http2",
+                "Origins": [
+                    {
+                        "S3OriginConfig": {
+                            "OriginAccessIdentity": {
+                                "Fn::Join": [
+                                    "",
+                                    [
+                                        "origin-access-identity/cloudfront/",
+                                        {
+                                            "Ref": "TestS3wDistCloudfrontOai"
+                                        }
+                                    ]
+                                ]
+                            }
+                        },
+                        "DomainName": "host-bucket.s3.amazonaws.com",
+                        "Id": "S3Origin"
+                    }
+                ],
+                "ViewerCertificate": {
+                    "AcmCertificateArn": "acm_arn",
+                    "SslSupportMethod": "sni-only"
+                }
+            }
+        },
+        "Type": "AWS::CloudFront::Distribution"
+    },
+    "TestS3wDistCloudfrontOai": {
+        "Properties": {
+            "CloudFrontOriginAccessIdentityConfig": {
+                "Comment": "test-s3w-dist Cloudfront origin access identity"
+            }
+        },
+        "Type": "AWS::CloudFront::CloudFrontOriginAccessIdentity"
+    },
+    "TestS3wDistCacheInvalidationLambdaPolicy": {
+        "Properties": {
+            "Description": "managed policy used by test-s3w-dist-cache-invalidation-lambda",
+            "ManagedPolicyName": "test-s3w-dist-cache-invalidation-lambda-policy",
+            "PolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": [
+                            "cloudfront:CreateInvalidation"
+                        ],
+                        "Resource": {
+                            "Fn::Join": [
+                                "",
+                                [
+                                    "arn:aws:cloudfront::",
+                                    {
+                                        "Ref": "AWS::AccountId"
+                                    },
+                                    ":distribution ",
+                                    {
+                                        "Ref": "TestS3wDist"
+                                    }
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            },
+            "Path": "/test-stack/"
+        },
+        "Type": "AWS::IAM::ManagedPolicy"
+    },
+    "TestS3wDistCacheInvalidationLambdaRole": {
+        "Properties": {
+            "RoleName": "test-s3w-dist-cache-invalidation-lambda-role",
+            "Description": "role assumed by test-s3w-dist-cache-invalidation-lambda",
+            "ManagedPolicyArns": [
+                {
+                    "Ref": "TestS3wDistCacheInvalidationLambdaPolicy"
+                }
+            ],
+            "AssumeRolePolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": "sts:AssumeRole",
+                        "Principal": {
+                            "Service": [
+                                "lambda.amazonaws.com"
+                            ]
+                        }
+                    }
+                ]
+            },
+            "Tags": [
+                {
+                    "Key": "Name",
+                    "Value": "test-s3w-dist-cache-invalidation-lambda-role"
+                }
+            ],
+            "Path": "/test-stack/"
+        },
+        "Type": "AWS::IAM::Role"
+    },
+    "TestS3wDistCacheInvalidationLambda": {
+        "Properties": {
+            "Code": {
+                "ZipFile": {
+                    "Fn::Join": [
+                        "\n",
+                        [
+                            "import boto3",
+                            "import time  # noqa: F401",
+                            "",
+                            "",
+                            "def handler(event, context):",
+                            "    path = []",
+                            "    client = boto3.client(\"cloudfront\")  # noqa: F841",
+                            "    for items in event[\"Records\"]:",
+                            "        if items[\"s3\"][\"object\"][\"key\"] == \"index.html\":",
+                            "            path.append(\"/\")",
+                            "        else:",
+                            "            path.append(\"/\" + items[\"s3\"][\"object\"][\"key\"])",
+                            "    client.create_invalidation(",
+                            {
+                                "Fn::Sub": [
+                                    "        DistributionId='${distribution_id}',",
+                                    {
+                                        "distribution_id": {
+                                            "Ref": "TestS3wDist"
+                                        }
+                                    }
+                                ]
+                            },
+                            "        InvalidationBatch={",
+                            "            'Paths': {'Quantity': 1, 'Items': path},",
+                            "            'CallerReference': str(time.time()),",
+                            "        },",
+                            "    )"
+                        ]
+                    ]
+                }
+            },
+            "Timeout": 3,
+            "Description": "lambda invalidating cloudfront cache when host-bucket objects are updated",
+            "Role": {
+                "Fn::GetAtt": [
+                    "TestS3wDistCacheInvalidationLambdaRole",
+                    "Arn"
+                ]
+            },
+            "FunctionName": "TestS3wDistCacheInvalidationLambda",
+            "Runtime": "python3.9",
+            "Handler": "invalidate.handler"
+        },
+        "Type": "AWS::Lambda::Function"
+    },
+    "TestS3wDistInvalidationTopic": {
+        "Properties": {
+            "TopicName": "test-s3w-dist-invalidation-topic",
+            "Subscription": []
+        },
+        "Type": "AWS::SNS::Topic"
+    },
+    "TestS3wDistCacheInvalidationLambdaSub": {
+        "Properties": {
+            "Endpoint": {
+                "Fn::GetAtt": [
+                    "TestS3wDistCacheInvalidationLambda",
+                    "Arn"
+                ]
+            },
+            "Protocol": "lambda",
+            "TopicArn": {
+                "Ref": "TestS3wDistInvalidationTopic"
+            },
+            "DeliveryPolicy": {
+                "throttlePolicy": {
+                    "maxReceivesPerSecond": 10
+                }
+            }
+        },
+        "Type": "AWS::SNS::Subscription"
+    },
+    "TestS3wDistCacheInvalidationLambdatestS3wDistInvalidationTopic": {
+        "Properties": {
+            "Action": "lambda:InvokeFunction",
+            "FunctionName": {
+                "Ref": "TestS3wDistCacheInvalidationLambda"
+            },
+            "Principal": "sns.amazonaws.com",
+            "SourceArn": {
+                "Ref": "TestS3wDistInvalidationTopic"
+            }
+        },
+        "Type": "AWS::Lambda::Permission"
+    },
+    "TestS3wDistTests3wcomR53Rset": {
+        "Properties": {
+            "AliasTarget": {
+                "DNSName": {
+                    "Fn::GetAtt": [
+                        "TestS3wDist",
+                        "DomainName"
+                    ]
+                },
+                "HostedZoneId": "Z2FDTNDATAQYW2"
+            },
+            "Name": "test.s3w.com",
+            "HostedZoneId": "hosted_zone_id",
+            "Type": "A"
+        },
+        "Type": "AWS::Route53::RecordSet"
+    }
+}


### PR DESCRIPTION
This construct provides a cloudfront distribution in front of a website
hosted in S3 and a lambda invalidating cloudfront cache when s3 objects
are updated.