### PR TITLE
Add s3 bucket encryption options

### DIFF
--- a/tests/tests_e3_aws/troposphere/s3/bucket.json
+++ b/tests/tests_e3_aws/troposphere/s3/bucket.json
@@ -1,0 +1,220 @@
+{
+    "TestTopic": {
+        "Properties": {
+            "TopicName": "test-topic",
+            "Subscription": []
+        },
+        "Type": "AWS::SNS::Topic"
+    },
+    "TestQueue": {
+        "Properties": {
+            "QueueName": "test-queue",
+            "VisibilityTimeout": 30
+        },
+        "Type": "AWS::SQS::Queue"
+    },
+    "Mypylambda": {
+        "Properties": {
+            "Code": {
+                "S3Bucket": "cfn_bucket",
+                "S3Key": "templates/mypylambda_lambda.zip"
+            },
+            "Timeout": 3,
+            "Description": "this is a test",
+            "Role": "somearn",
+            "FunctionName": "mypylambda",
+            "Runtime": "python3.8",
+            "Handler": "app.main"
+        },
+        "Type": "AWS::Lambda::Function"
+    },
+    "TestBucket": {
+        "Properties": {
+            "BucketName": "test-bucket",
+            "BucketEncryption": {
+                "ServerSideEncryptionConfiguration": [
+                    {
+                        "ServerSideEncryptionByDefault": {
+                            "SSEAlgorithm": "AES256"
+                        }
+                    }
+                ]
+            },
+            "PublicAccessBlockConfiguration": {
+                "BlockPublicAcls": true,
+                "BlockPublicPolicy": true,
+                "IgnorePublicAcls": true,
+                "RestrictPublicBuckets": true
+            },
+            "VersioningConfiguration": {
+                "Status": "Enabled"
+            },
+            "NotificationConfiguration": {
+                "LambdaConfigurations": [
+                    {
+                        "Event": "s3:ObjectCreated:*",
+                        "Function": {
+                            "Fn::GetAtt": [
+                                "Mypylambda",
+                                "Arn"
+                            ]
+                        }
+                    }
+                ],
+                "TopicConfigurations": [
+                    {
+                        "Event": "s3:ObjectCreated:*",
+                        "Topic": {
+                            "Ref": "TestTopic"
+                        }
+                    }
+                ],
+                "QueueConfigurations": [
+                    {
+                        "Event": "s3:ObjectCreated:*",
+                        "Queue": {
+                            "Fn::GetAtt": [
+                                "TestQueue",
+                                "Arn"
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "Type": "AWS::S3::Bucket",
+        "DependsOn": [
+            "TestTopicPolicyTpUpload",
+            "TestQueuePolicyFileEvent"
+        ]
+    },
+    "TestBucketPolicy": {
+        "Properties": {
+            "Bucket": {
+                "Ref": "TestBucket"
+            },
+            "PolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Deny",
+                        "Principal": {
+                            "AWS": "*"
+                        },
+                        "Action": "s3:*",
+                        "Resource": "arn:aws:s3:::test-bucket/*",
+                        "Condition": {
+                            "Bool": {
+                                "aws:SecureTransport": "false"
+                            }
+                        }
+                    },
+                    {
+                        "Effect": "Deny",
+                        "Principal": {
+                            "AWS": "*"
+                        },
+                        "Action": "s3:PutObject",
+                        "Resource": "arn:aws:s3:::test-bucket/*",
+                        "Condition": {
+                            "StringNotEquals": {
+                                "s3:x-amz-server-side-encryption": "AES256"
+                            }
+                        }
+                    },
+                    {
+                        "Effect": "Deny",
+                        "Principal": {
+                            "AWS": "*"
+                        },
+                        "Action": "s3:PutObject",
+                        "Resource": "arn:aws:s3:::test-bucket/*",
+                        "Condition": {
+                            "Null": {
+                                "s3:x-amz-server-side-encryption": "true"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "Type": "AWS::S3::BucketPolicy"
+    },
+    "MypylambdaTpUpload": {
+        "Properties": {
+            "Action": "lambda:InvokeFunction",
+            "FunctionName": {
+                "Ref": "Mypylambda"
+            },
+            "Principal": "s3.amazonaws.com",
+            "SourceArn": "arn:aws:s3:::test-bucket",
+            "SourceAccount": {
+                "Ref": "AWS::AccountId"
+            }
+        },
+        "Type": "AWS::Lambda::Permission"
+    },
+    "TestTopicPolicyTpUpload": {
+        "Properties": {
+            "Topics": [
+                {
+                    "Ref": "TestTopic"
+                }
+            ],
+            "PolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Principal": {
+                            "Service": "s3.amazonaws.com"
+                        },
+                        "Action": "sns:Publish",
+                        "Resource": {
+                            "Ref": "TestTopic"
+                        },
+                        "Condition": {
+                            "ArnLike": {
+                                "aws:SourceArn": "arn:aws:s3:::test-bucket"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "Type": "AWS::SNS::TopicPolicy"
+    },
+    "TestQueuePolicyFileEvent": {
+        "Properties": {
+            "PolicyDocument": {
+                "Statement": [
+                    {
+                        "Action": "sqs:SendMessage",
+                        "Condition": {
+                            "ArnLike": {
+                                "aws:SourceArn": "arn:aws:s3:::test-bucket"
+                            }
+                        },
+                        "Effect": "Allow",
+                        "Principal": {
+                            "Service": "s3.amazonaws.com"
+                        },
+                        "Resource": {
+                            "Fn::GetAtt": [
+                                "TestQueue",
+                                "Arn"
+                            ]
+                        }
+                    }
+                ],
+                "Version": "2012-10-17"
+            },
+            "Queues": [
+                {
+                    "Ref": "TestQueue"
+                }
+            ]
+        },
+        "Type": "AWS::SQS::QueuePolicy"
+    }
+}

--- a/tests/tests_e3_aws/troposphere/s3/bucket_multi_encryption.json
+++ b/tests/tests_e3_aws/troposphere/s3/bucket_multi_encryption.json
@@ -1,0 +1,72 @@
+{
+    "TestBucket": {
+        "Properties": {
+            "BucketName": "test-bucket",
+            "PublicAccessBlockConfiguration": {
+                "BlockPublicAcls": true,
+                "BlockPublicPolicy": true,
+                "IgnorePublicAcls": true,
+                "RestrictPublicBuckets": true
+            },
+            "VersioningConfiguration": {
+                "Status": "Enabled"
+            }
+        },
+        "Type": "AWS::S3::Bucket"
+    },
+    "TestBucketPolicy": {
+        "Properties": {
+            "Bucket": {
+                "Ref": "TestBucket"
+            },
+            "PolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Deny",
+                        "Principal": {
+                            "AWS": "*"
+                        },
+                        "Action": "s3:*",
+                        "Resource": "arn:aws:s3:::test-bucket/*",
+                        "Condition": {
+                            "Bool": {
+                                "aws:SecureTransport": "false"
+                            }
+                        }
+                    },
+                    {
+                        "Effect": "Deny",
+                        "Principal": {
+                            "AWS": "*"
+                        },
+                        "Action": "s3:PutObject",
+                        "Resource": "arn:aws:s3:::test-bucket/*",
+                        "Condition": {
+                            "ForAllValues:StringNotEquals": {
+                                "s3:x-amz-server-side-encryption": [
+                                    "AES256",
+                                    "kms:aws"
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "Effect": "Deny",
+                        "Principal": {
+                            "AWS": "*"
+                        },
+                        "Action": "s3:PutObject",
+                        "Resource": "arn:aws:s3:::test-bucket/*",
+                        "Condition": {
+                            "Null": {
+                                "s3:x-amz-server-side-encryption": "true"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "Type": "AWS::S3::BucketPolicy"
+    }
+}

--- a/tests/tests_e3_aws/troposphere/s3/s3_test.py
+++ b/tests/tests_e3_aws/troposphere/s3/s3_test.py
@@ -1,160 +1,15 @@
 """Provide S3 construct tests."""
+import json
+import os
 
-from e3.aws.troposphere.s3.bucket import Bucket
+from e3.aws.troposphere.s3.bucket import Bucket, EncryptionAlgorithm
 from e3.aws.troposphere import Stack
 from e3.aws.troposphere.awslambda import Py38Function
 from e3.aws.troposphere.sns import Topic
 from e3.aws.troposphere.sqs import Queue
 
-EXPECTED_TEMPLATE = {
-    "TestTopic": {
-        "Properties": {"TopicName": "test-topic", "Subscription": []},
-        "Type": "AWS::SNS::Topic",
-    },
-    "TestQueue": {
-        "Properties": {"QueueName": "test-queue", "VisibilityTimeout": 30},
-        "Type": "AWS::SQS::Queue",
-    },
-    "Mypylambda": {
-        "Properties": {
-            "Code": {
-                "S3Bucket": "cfn_bucket",
-                "S3Key": "templates/mypylambda_lambda.zip",
-            },
-            "Timeout": 3,
-            "Description": "this is a test",
-            "Role": "somearn",
-            "FunctionName": "mypylambda",
-            "Runtime": "python3.8",
-            "Handler": "app.main",
-        },
-        "Type": "AWS::Lambda::Function",
-    },
-    "TestBucket": {
-        "Properties": {
-            "BucketName": "test-bucket",
-            "BucketEncryption": {
-                "ServerSideEncryptionConfiguration": [
-                    {"ServerSideEncryptionByDefault": {"SSEAlgorithm": "AES256"}}
-                ]
-            },
-            "PublicAccessBlockConfiguration": {
-                "BlockPublicAcls": True,
-                "BlockPublicPolicy": True,
-                "IgnorePublicAcls": True,
-                "RestrictPublicBuckets": True,
-            },
-            "VersioningConfiguration": {"Status": "Enabled"},
-            "NotificationConfiguration": {
-                "LambdaConfigurations": [
-                    {
-                        "Event": "s3:ObjectCreated:*",
-                        "Function": {"Fn::GetAtt": ["Mypylambda", "Arn"]},
-                    }
-                ],
-                "TopicConfigurations": [
-                    {"Event": "s3:ObjectCreated:*", "Topic": {"Ref": "TestTopic"}}
-                ],
-                "QueueConfigurations": [
-                    {
-                        "Event": "s3:ObjectCreated:*",
-                        "Queue": {"Fn::GetAtt": ["TestQueue", "Arn"]},
-                    }
-                ],
-            },
-        },
-        "Type": "AWS::S3::Bucket",
-        "DependsOn": ["TestTopicPolicyTpUpload", "TestQueuePolicyFileEvent"],
-    },
-    "TestBucketPolicy": {
-        "Properties": {
-            "Bucket": {"Ref": "TestBucket"},
-            "PolicyDocument": {
-                "Version": "2012-10-17",
-                "Statement": [
-                    {
-                        "Effect": "Deny",
-                        "Principal": {"AWS": "*"},
-                        "Action": "s3:*",
-                        "Resource": "arn:aws:s3:::test-bucket/*",
-                        "Condition": {"Bool": {"aws:SecureTransport": "false"}},
-                    },
-                    {
-                        "Effect": "Deny",
-                        "Principal": {"AWS": "*"},
-                        "Action": "s3:PutObject",
-                        "Resource": "arn:aws:s3:::test-bucket/*",
-                        "Condition": {
-                            "StringNotEquals": {
-                                "s3:x-amz-server-side-encryption": "AES256"
-                            }
-                        },
-                    },
-                    {
-                        "Effect": "Deny",
-                        "Principal": {"AWS": "*"},
-                        "Action": "s3:PutObject",
-                        "Resource": "arn:aws:s3:::test-bucket/*",
-                        "Condition": {
-                            "Null": {"s3:x-amz-server-side-encryption": "true"}
-                        },
-                    },
-                ],
-            },
-        },
-        "Type": "AWS::S3::BucketPolicy",
-    },
-    "MypylambdaTpUpload": {
-        "Properties": {
-            "Action": "lambda:InvokeFunction",
-            "FunctionName": {"Ref": "Mypylambda"},
-            "Principal": "s3.amazonaws.com",
-            "SourceArn": "arn:aws:s3:::test-bucket",
-            "SourceAccount": {"Ref": "AWS::AccountId"},
-        },
-        "Type": "AWS::Lambda::Permission",
-    },
-    "TestTopicPolicyTpUpload": {
-        "Properties": {
-            "Topics": [{"Ref": "TestTopic"}],
-            "PolicyDocument": {
-                "Version": "2012-10-17",
-                "Statement": [
-                    {
-                        "Effect": "Allow",
-                        "Principal": {"Service": "s3.amazonaws.com"},
-                        "Action": "sns:Publish",
-                        "Resource": {"Ref": "TestTopic"},
-                        "Condition": {
-                            "ArnLike": {"aws:SourceArn": "arn:aws:s3:::test-bucket"}
-                        },
-                    }
-                ],
-            },
-        },
-        "Type": "AWS::SNS::TopicPolicy",
-    },
-    "TestQueuePolicyFileEvent": {
-        "Properties": {
-            "PolicyDocument": {
-                "Statement": [
-                    {
-                        "Action": "sqs:SendMessage",
-                        "Condition": {
-                            "ArnLike": {"aws:SourceArn": "arn:aws:s3:::test-bucket"}
-                        },
-                        "Effect": "Allow",
-                        "Principal": {"Service": "s3.amazonaws.com"},
-                        "Resource": {"Fn::GetAtt": ["TestQueue", "Arn"]},
-                    }
-                ],
-                "Version": "2012-10-17",
-            },
-            "Queues": [{"Ref": "TestQueue"}],
-        },
-        "Type": "AWS::SQS::QueuePolicy",
-    },
-}
+
+TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 def test_bucket(stack: Stack) -> None:
@@ -188,4 +43,22 @@ def test_bucket(stack: Stack) -> None:
     )
     stack.add(bucket)
 
-    assert stack.export()["Resources"] == EXPECTED_TEMPLATE
+    with open(os.path.join(TEST_DIR, "bucket.json")) as fd:
+        expected_template = json.load(fd)
+
+    assert stack.export()["Resources"] == expected_template
+
+
+def test_bucket_multi_encryption(stack: Stack) -> None:
+    """Test bucket accepting multiple types of encryptions and without default."""
+    bucket = Bucket(
+        name="test-bucket",
+        default_bucket_encryption=None,
+        authorized_encryptions=[EncryptionAlgorithm.AES256, EncryptionAlgorithm.KMS],
+    )
+    stack.add(bucket)
+
+    with open(os.path.join(TEST_DIR, "bucket_multi_encryption.json")) as fd:
+        expected_template = json.load(fd)
+
+    assert stack.export()["Resources"] == expected_template


### PR DESCRIPTION
Add the possibility to support multiple server-side-encryption
algorithms and to disable default encryption. These settings are needed
for cloudtrail logs buckets.

TN: V121-025