### PR TITLE
Fix typo in kms encryption value

### DIFF
--- a/src/e3/aws/troposphere/s3/bucket.py
+++ b/src/e3/aws/troposphere/s3/bucket.py
@@ -26,7 +26,7 @@ class EncryptionAlgorithm(Enum):
     """Provide an Enum to describe encryption algorithms."""
 
     AES256 = "AES256"
-    KMS = "kms:aws"
+    KMS = "aws:kms"
 
 
 class Bucket(Construct):

--- a/tests/tests_e3_aws/troposphere/s3/bucket_multi_encryption.json
+++ b/tests/tests_e3_aws/troposphere/s3/bucket_multi_encryption.json
@@ -46,7 +46,7 @@
                             "ForAllValues:StringNotEquals": {
                                 "s3:x-amz-server-side-encryption": [
                                     "AES256",
-                                    "kms:aws"
+                                    "aws:kms"
                                 ]
                             }
                         }


### PR DESCRIPTION
It was set to kms:aws instead of aws:kms.

TN: V121-025