### PR TITLE
Only authorize TLSv1.2 and 1.3 for S3 websites

### DIFF
--- a/src/e3/aws/troposphere/cloudfront/__init__.py
+++ b/src/e3/aws/troposphere/cloudfront/__init__.py
@@ -155,7 +155,9 @@ class S3WebsiteDistribution(Construct):
                 HttpVersion="http2",
                 Origins=[origin],
                 ViewerCertificate=cloudfront.ViewerCertificate(
-                    AcmCertificateArn=self.certificate_arn, SslSupportMethod="sni-only"
+                    AcmCertificateArn=self.certificate_arn,
+                    SslSupportMethod="sni-only",
+                    MinimumProtocolVersion="TLSv1.2_2021",
                 ),
             ),
         )

--- a/tests/tests_e3_aws/troposphere/s3websitedistribution.json
+++ b/tests/tests_e3_aws/troposphere/s3websitedistribution.json
@@ -174,7 +174,8 @@
                 ],
                 "ViewerCertificate": {
                     "AcmCertificateArn": "acm_arn",
-                    "SslSupportMethod": "sni-only"
+                    "SslSupportMethod": "sni-only",
+                    "MinimumProtocolVersion": "TLSv1.2_2021"
                 }
             }
         },


### PR DESCRIPTION
TLSv1.0 and 1.1 were accepted by default.

TN: V316-043