### PR TITLE
Update VPC Construct to have NAT and pub/priv subnets

### DIFF
--- a/src/e3/aws/troposphere/events/rule.py
+++ b/src/e3/aws/troposphere/events/rule.py
@@ -46,13 +46,18 @@ class FargateScheduledTaskRule(Construct):
 
         :param task_name: name of the task
         """
+        if isinstance(self.vpc, EcsVPC):
+            subnet = self.vpc.subnet
+        else:
+            subnet = self.vpc.main_subnet
+
         return events.EcsParameters(
             LaunchType="FARGATE",
             NetworkConfiguration=events.NetworkConfiguration(
                 AwsVpcConfiguration=events.AwsVpcConfiguration(
                     AssignPublicIp="DISABLED",
                     SecurityGroups=[Ref(self.vpc.security_group)],
-                    Subnets=[Ref(self.vpc.subnet)],
+                    Subnets=[Ref(subnet)],
                 )
             ),
             TaskDefinitionArn=Ref(name_to_id(f"{task_name}")),

--- a/tests/tests_e3_aws/troposphere/ec2/ec2_test.py
+++ b/tests/tests_e3_aws/troposphere/ec2/ec2_test.py
@@ -63,6 +63,7 @@ def test_vpc(stack: Stack) -> None:
             name="TestVPC",
             region="eu-west-1",
             internet_gateway=True,
+            nat_gateway=True,
             s3_endpoint_policy_document=s3_endpoint_pd,
             interface_endpoints=[
                 ("logs", cloudwatch_endpoint_pd),

--- a/tests/tests_e3_aws/troposphere/ec2/vpc.json
+++ b/tests/tests_e3_aws/troposphere/ec2/vpc.json
@@ -1,33 +1,7 @@
 {
-    "TestVPCIgw": {
-        "Type": "AWS::EC2::InternetGateway"
-    },
-    "TestVPCIgwAttachement": {
-        "Properties": {
-            "InternetGatewayId": {
-                "Ref": "TestVPCIgw"
-            },
-            "VpcId": {
-                "Ref": "TestVPC"
-            }
-        },
-        "Type": "AWS::EC2::VPCGatewayAttachment"
-    },
-    "TestVPCIgwRoute": {
-        "Properties": {
-            "RouteTableId": {
-                "Ref": "TestVPCRouteTable"
-            },
-            "DestinationCidrBlock": "0.0.0.0/0",
-            "GatewayId": {
-                "Ref": "TestVPCIgw"
-            }
-        },
-        "Type": "AWS::EC2::Route"
-    },
     "TestVPC": {
         "Properties": {
-            "CidrBlock": "10.0.0.0/16",
+            "CidrBlock": "10.10.0.0/16",
             "EnableDnsHostnames": true,
             "EnableDnsSupport": true,
             "Tags": [
@@ -38,21 +12,6 @@
             ]
         },
         "Type": "AWS::EC2::VPC"
-    },
-    "TestVPCSubnet": {
-        "Properties": {
-            "VpcId": {
-                "Ref": "TestVPC"
-            },
-            "CidrBlock": "10.0.64.0/18",
-            "Tags": [
-                {
-                    "Key": "Name",
-                    "Value": "TestVPCSubnet"
-                }
-            ]
-        },
-        "Type": "AWS::EC2::Subnet"
     },
     "TestVPCSecurityGroup": {
         "Properties": {
@@ -85,7 +44,22 @@
         },
         "Type": "AWS::EC2::SecurityGroupEgress"
     },
-    "TestVPCRouteTable": {
+    "TestVPCPrivateSubnet": {
+        "Properties": {
+            "VpcId": {
+                "Ref": "TestVPC"
+            },
+            "CidrBlock": "10.10.0.0/17",
+            "Tags": [
+                {
+                    "Key": "Name",
+                    "Value": "TestVPCPrivateSubnet"
+                }
+            ]
+        },
+        "Type": "AWS::EC2::Subnet"
+    },
+    "TestVPCPrivateSubnetRouteTable": {
         "Properties": {
             "VpcId": {
                 "Ref": "TestVPC"
@@ -93,16 +67,105 @@
         },
         "Type": "AWS::EC2::RouteTable"
     },
-    "TestVPCRouteTableAssoc": {
+    "TestVPCPrivateSubnetRouteTableAssoc": {
         "Properties": {
             "RouteTableId": {
-                "Ref": "TestVPCRouteTable"
+                "Ref": "TestVPCPrivateSubnetRouteTable"
             },
             "SubnetId": {
-                "Ref": "TestVPCSubnet"
+                "Ref": "TestVPCPrivateSubnet"
             }
         },
         "Type": "AWS::EC2::SubnetRouteTableAssociation"
+    },
+    "TestVPCPrivateSubnetNatRoute": {
+        "Properties": {
+            "RouteTableId": {
+                "Ref": "TestVPCPrivateSubnetRouteTable"
+            },
+            "DestinationCidrBlock": "0.0.0.0/0",
+            "NatGatewayId": {
+                "Ref": "TestVPCPublicSubnetNat"
+            }
+        },
+        "Type": "AWS::EC2::Route"
+    },
+    "TestVPCPublicSubnet": {
+        "Properties": {
+            "VpcId": {
+                "Ref": "TestVPC"
+            },
+            "CidrBlock": "10.10.128.0/18",
+            "Tags": [
+                {
+                    "Key": "Name",
+                    "Value": "TestVPCPublicSubnet"
+                }
+            ]
+        },
+        "Type": "AWS::EC2::Subnet"
+    },
+    "TestVPCPublicSubnetRouteTable": {
+        "Properties": {
+            "VpcId": {
+                "Ref": "TestVPC"
+            }
+        },
+        "Type": "AWS::EC2::RouteTable"
+    },
+    "TestVPCPublicSubnetRouteTableAssoc": {
+        "Properties": {
+            "RouteTableId": {
+                "Ref": "TestVPCPublicSubnetRouteTable"
+            },
+            "SubnetId": {
+                "Ref": "TestVPCPublicSubnet"
+            }
+        },
+        "Type": "AWS::EC2::SubnetRouteTableAssociation"
+    },
+    "TestVPCPublicSubnetIgw": {
+        "Type": "AWS::EC2::InternetGateway"
+    },
+    "TestVPCPublicSubnetIgwAttachement": {
+        "Properties": {
+            "InternetGatewayId": {
+                "Ref": "TestVPCPublicSubnetIgw"
+            },
+            "VpcId": {
+                "Ref": "TestVPC"
+            }
+        },
+        "Type": "AWS::EC2::VPCGatewayAttachment"
+    },
+    "TestVPCPublicSubnetIgwRoute": {
+        "Properties": {
+            "RouteTableId": {
+                "Ref": "TestVPCPublicSubnetRouteTable"
+            },
+            "DestinationCidrBlock": "0.0.0.0/0",
+            "GatewayId": {
+                "Ref": "TestVPCPublicSubnetIgw"
+            }
+        },
+        "Type": "AWS::EC2::Route"
+    },
+    "TestVPCPublicSubnetNat": {
+        "Properties": {
+            "AllocationId": {
+                "Fn::GetAtt": [
+                    "TestVPCPublicSubnetEip",
+                    "AllocationId"
+                ]
+            },
+            "SubnetId": {
+                "Ref": "TestVPCPublicSubnet"
+            }
+        },
+        "Type": "AWS::EC2::NatGateway"
+    },
+    "TestVPCPublicSubnetEip": {
+        "Type": "AWS::EC2::EIP"
     },
     "TestVPCS3Endpoint": {
         "Properties": {
@@ -128,7 +191,7 @@
             },
             "RouteTableIds": [
                 {
-                    "Ref": "TestVPCRouteTable"
+                    "Ref": "TestVPCPrivateSubnetRouteTable"
                 }
             ],
             "ServiceName": "com.amazonaws.eu-west-1.s3",
@@ -156,7 +219,7 @@
             "VpcId": {
                 "Ref": "TestVPC"
             },
-            "CidrBlock": "10.0.128.0/18",
+            "CidrBlock": "10.10.192.0/18",
             "Tags": [
                 {
                     "Key": "Name",
@@ -179,7 +242,7 @@
     },
     "TestVPCVpcEndpointsSubnetDefaultEgress": {
         "Properties": {
-            "CidrIp": "10.0.128.0/18",
+            "CidrIp": "10.10.192.0/18",
             "IpProtocol": "-1",
             "GroupId": {
                 "Ref": "TestVPCVpcEndpointsSubnetSecurityGroup"


### PR DESCRIPTION
VPC can optionnaly have a public subnet separated from the private
subnet using a NAT gateway to route traffic from the private subnet to
the Internet. NAT also provides a way for ecs tasks running in the
private subnet to get an Elastic IP address.

TN: V314-014