### PR TITLE
Require docker only on Linux systems

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,9 @@ setup(
     install_requires=(
         "boto3",
         "botocore",
-        "docker",
+        # Only require docker for linux as there is a known dependency issue
+        # with pywin32 on windows
+        "docker; platform_system=='Linux'",
         "pyyaml",
         "troposphere",
         "e3-core",


### PR DESCRIPTION
There is a known issue with docker-py pywin32 dependency pinned to
version 227 (https://github.com/docker/docker-py/issues/2835).

TN: V425-021