### PR TITLE
Add support for 2FA on the command line

### DIFF
--- a/src/e3/aws/__init__.py
+++ b/src/e3/aws/__init__.py
@@ -149,6 +149,12 @@ class Session:
         if session_duration is not None:
             arguments["DurationSeconds"] = session_duration
 
+        # If AWS_MFA_DEVICE is in the environment ask user for OTP
+        if "AWS_MFA_DEVICE" in os.environ:  # all: no cover
+            arguments["SerialNumber"] = os.environ["AWS_MFA_DEVICE"]
+            otp = input("Enter MFA code: ")
+            arguments["TokenCode"] = otp
+
         response = client.assume_role(**arguments)
 
         credentials = response["Credentials"]

--- a/src/e3/aws/troposphere/iam/policy_statement.py
+++ b/src/e3/aws/troposphere/iam/policy_statement.py
@@ -104,7 +104,7 @@ class Trust(PolicyStatement):
         accounts: Optional[list[str]] = None,
         users: Optional[list[tuple[str, str]]] = None,
         condition: Optional[ConditionType] = None,
-        actions: Optional[list[str] | str] = None,
+        actions: list[str] | str = "sts:AssumeRole",
     ) -> None:
         """Initialize a trust policy statement.
 
@@ -137,13 +137,11 @@ class Trust(PolicyStatement):
 
         self.condition = condition
         self.actions = actions
-        if self.actions is None:
-            self.actions = "sts:AssumeRole"
 
     @property
     def as_dict(self) -> dict[str, Any]:
         """See PolicyStatement doc."""
-        result = {
+        result: dict[str, str | list[str] | dict[str, list[str]] | ConditionType] = {
             "Effect": "Allow",
             "Action": self.actions,
             "Principal": self.principals,


### PR DESCRIPTION
Check if AWS_MFA_DEVICE variable is defined. If yes ask the user for
its code before doing an assume_role