### PR TITLE
Add CFNProjectMain class to facilitate CFN projects deployment

### DIFF
--- a/src/e3/aws/cfn/main.py
+++ b/src/e3/aws/cfn/main.py
@@ -12,14 +12,14 @@ from typing import TYPE_CHECKING
 import botocore.exceptions
 
 from e3.aws import AWSEnv, Session
-from e3.aws.troposphere import Stack as TroposphereStack
+from e3.aws.cfn import Stack
 from e3.env import Env
 from e3.fs import find, sync_tree
 from e3.main import Main
 
+
 if TYPE_CHECKING:
     from typing import List, Optional, Tuple, Union
-    from e3.aws.cfn import Stack
 
 
 class CFNMain(Main, metaclass=abc.ABCMeta):
@@ -281,10 +281,15 @@ class CFNMain(Main, metaclass=abc.ABCMeta):
                 else:
                     print("No stack policy to set")
             elif self.args.command == "show-cfn-policy":
-                if isinstance(stack, TroposphereStack):
-                    print(json.dumps(stack.cfn_policy_document().as_dict, indent=2))
-                else:
-                    print("command supported only with troposphere stacks")
+                try:
+                    print(
+                        json.dumps(
+                            stack.cfn_policy_document().as_dict,  # type: ignore
+                            indent=2,
+                        )
+                    )
+                except AttributeError as attr_e:
+                    print(f"command supported only with troposphere stacks: {attr_e}")
             elif self.args.command == "delete":
                 stack.delete(wait=self.args.wait_stack_creation)
 

--- a/tests/tests_e3_aws/troposphere/cfn_project_test.out
+++ b/tests/tests_e3_aws/troposphere/cfn_project_test.out
@@ -1,0 +1,19 @@
+Description: TestStack
+Resources:
+  TestRole:
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Action: sts:AssumeRole
+          Effect: Allow
+          Principal:
+            Service: test
+        Version: '2012-10-17'
+      Description: TestRole description
+      Path: /
+      RoleName: TestRole
+      Tags:
+      - Key: Name
+        Value: TestRole
+    Type: AWS::IAM::Role
+

--- a/tests/tests_e3_aws/troposphere/cfn_project_test.py
+++ b/tests/tests_e3_aws/troposphere/cfn_project_test.py
@@ -1,0 +1,52 @@
+"""Provide Cloudformation construct tests."""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from e3.aws import AWSEnv
+from e3.aws.troposphere import CFNProjectMain
+from e3.aws.troposphere.iam.role import Role
+
+
+if TYPE_CHECKING:
+    from e3.aws.troposphere import Stack
+
+
+TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+class MyCFNProject(CFNProjectMain):
+    """Provide CLI to manage MyCFNProject."""
+
+    def create_stack(self) -> list[Stack]:
+        """Return MyCFNProject stack."""
+        self.add(
+            (
+                Role(
+                    name="TestRole",
+                    description="TestRole description",
+                    trust={"Service": "test"},
+                )
+            )
+        )
+        return self.stack
+
+
+def test_cfn_project_main(capfd) -> None:
+    """Test CFNProjectMain."""
+    aws_env = AWSEnv(regions=["eu-west-1"], stub=True)
+    test = MyCFNProject(
+        name="TestProject",
+        account_id="12345678",
+        stack_description="TestStack",
+        s3_bucket="cfn-test-deploy-bucket",
+        regions=["eu-west-1"],
+    )
+    test.execute(args=["show"], aws_env=aws_env)
+
+    captured = capfd.readouterr()
+    print(captured.out)
+    with open(os.path.join(TEST_DIR, "cfn_project_test.out")) as f_out:
+        assert captured.out == f_out.read()


### PR DESCRIPTION
This class inheritates from CFNMain and set some default values
for stack deployement parameters to avoid having to set it for each
project when using the same convention for each project.