### PR TITLE
Fix CFNProjectMain's stack s3_key

### DIFF
--- a/src/e3/aws/troposphere/__init__.py
+++ b/src/e3/aws/troposphere/__init__.py
@@ -194,7 +194,7 @@ class CFNProjectMain(CFNMain):
             cfn_role_arn=f"arn:aws:iam::{account_id}:role/cfn-service/CFNServiceRoleFor{name}",
             description=stack_description,
             s3_bucket=s3_bucket,
-            s3_key=name,
+            s3_key=self.s3_data_key,
         )
 
     def add(self, element: AWSObject | Construct | Stack) -> Stack:


### PR DESCRIPTION
This should be set to CFNProjectMain s3_data_key as it indicates where
data associated to the stack (e.g lambda code) should be uploaded.