### PR TITLE
Add a method to add an Interface endpoint to a Fortress

### DIFF
--- a/tests/tests_e3_aws/cfn/arch/main_test.py
+++ b/tests/tests_e3_aws/cfn/arch/main_test.py
@@ -94,7 +94,10 @@ def test_create_fortress(enable_github, requests_mock):
         f.add_secret_access("arn_secret")
 
         # Allow access to lambdas throught lambda endpoints
-        f.add_secret_access(["arn_lambda_1", "arn_lambda_2"])
+        f.add_lambda_access(["arn_lambda_1", "arn_lambda_2"])
+
+        # Allow access to sts service
+        f.add_service_access("sts")
 
         # allow https
         f.add_network_access("https")


### PR DESCRIPTION
This is usefull to enable access to AWS services through VPC endpoints
instead of Internet thus limiting the number of egress rules needed.

TN: V503-036