### PR TITLE
Fix secret rotation lambda policy name

### DIFF
--- a/src/e3/aws/troposphere/ec2/__init__.py
+++ b/src/e3/aws/troposphere/ec2/__init__.py
@@ -80,7 +80,9 @@ class InternetGateway(Construct):
                         RouteTableId=Ref(self.route_table),
                         SubnetId=Ref(subnet),
                     )
-                    for subnet, num in zip(self.subnets, range(len(self.subnets)))
+                    for subnet, num in zip(  # noqa: B905
+                        self.subnets, range(len(self.subnets))
+                    )
                 ]
             )
 

--- a/src/e3/aws/troposphere/secretsmanager/__init__.py
+++ b/src/e3/aws/troposphere/secretsmanager/__init__.py
@@ -31,7 +31,7 @@ class Secret(Construct):
     def rotation_lambda_policy(self) -> ManagedPolicy:
         """Return policy granting permissions to rotate the secret."""
         return ManagedPolicy(
-            name=f"{self.name}RotationPolicy",
+            name=name_to_id(f"{self.name}RotationPolicy"),
             description="Managed policy granting permissions"
             f"to rotate the {self.name} secret",
             statements=[

--- a/tests/tests_e3_aws/troposphere/ec2/igw_test.py
+++ b/tests/tests_e3_aws/troposphere/ec2/igw_test.py
@@ -74,7 +74,7 @@ def test_internet_gateway(stack: Stack, route_table_provided: bool) -> None:
             VpcId=Ref(vpc),
             MapPublicIpOnLaunch="true",
         )
-        for zone, ip in zip(
+        for zone, ip in zip(  # noqa: B905
             ["eu-west-1a", "eu-west-1b"], ["10.0.0.0/20", "10.0.16.0/20"]
         )
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps =
      cov: pytest-cov
      codecov: codecov
 
-passenv = APPVEYOR* CI GITHUB_* CODECOV_*
+passenv = APPVEYOR*,CI,GITHUB_*,CODECOV_*
 
 # Run testsuite with coverage when '-cov' is in the env name
 commands=


### PR DESCRIPTION
Secret names can include characters like - that are not supported for CloudFormation resource names.