### PR TITLE
Pass RoleARN in create_change_set

### DIFF
--- a/src/e3/aws/cfn/__init__.py
+++ b/src/e3/aws/cfn/__init__.py
@@ -646,19 +646,24 @@ class Stack(object):
             50Ko.
         :type url: str | None
         """
+        parameters = {
+            "ChangeSetName": name,
+            "StackName": self.name,
+            "Capabilities": ["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM"],
+        }
+
+        if self.cfn_role_arn is not None:
+            parameters["RoleARN"] = self.cfn_role_arn
+
         if url is None:
             return client.create_change_set(
-                ChangeSetName=name,
-                StackName=self.name,
                 TemplateBody=self.body,
-                Capabilities=["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM"],
+                **parameters,
             )
         else:
             return client.create_change_set(
-                ChangeSetName=name,
-                StackName=self.name,
                 TemplateURL=url,
-                Capabilities=["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM"],
+                **parameters,
             )
 
     @client("cloudformation")

--- a/tests/tests_e3_aws/cfn/main_test.py
+++ b/tests/tests_e3_aws/cfn/main_test.py
@@ -91,6 +91,29 @@ def test_create_change_set():
             s.create_change_set("name2", url="noprotocol://nothing")
 
 
+def test_create_change_set_role_arn():
+    s = Stack(name="teststack", cfn_role_arn="arn:aws:iam::123456789012:role/S3Access")
+
+    aws_env = AWSEnv(regions=["us-east-1"])
+    with default_region("us-east-1"):
+        cfn_client = aws_env.client("cloudformation", region="us-east-1")
+
+        stubber = Stubber(cfn_client)
+        stubber.add_response(
+            "create_change_set",
+            {},
+            {
+                "Capabilities": ["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM"],
+                "StackName": "teststack",
+                "ChangeSetName": "name1",
+                "TemplateBody": ANY,
+                "RoleARN": "arn:aws:iam::123456789012:role/S3Access",
+            },
+        )
+        with stubber:
+            s.create_change_set("name1")
+
+
 def test_validate():
     s = Stack(name="teststack")
 


### PR DESCRIPTION
A RoleARN parameter can be passed to create_change_set for updating the role associated with the Stack, which is required if the Stack is already deployed and the role changed