### PR TITLE
Always print output of pip install in create_data_dir

### DIFF
--- a/src/e3/aws/troposphere/awslambda/__init__.py
+++ b/src/e3/aws/troposphere/awslambda/__init__.py
@@ -422,9 +422,9 @@ class PyFunction(Function):
                     "-r",
                     self.requirement_file,
                 ],
-                output=None,
             )
-            assert p.status == 0
+            assert p.status == 0, p.out
+            logger.info(p.out)
 
         # Copy user code
         self.populate_package_dir(package_dir=package_dir)


### PR DESCRIPTION
The function create_data_dir is calling pip install to install requirements, but the output is only printed when there is a failure