### PR TITLE
Authorize HTTPS to VPC endpoints SG to all VPC IPs

### DIFF
--- a/tests/tests_e3_aws/troposphere/ec2/vpc.json
+++ b/tests/tests_e3_aws/troposphere/ec2/vpc.json
@@ -218,11 +218,9 @@
         },
         "Type": "AWS::EC2::SecurityGroupEgress"
     },
-    "TestVPCVPCEndpointsSubnetEgressTestVPCSecurityGroup": {
+    "TestVPCVPCEndpointsSubnetEgressToVPC": {
         "Properties": {
-            "DestinationSecurityGroupId": {
-                "Ref": "TestVPCSecurityGroup"
-            },
+            "CidrIp": "10.10.0.0/16",
             "FromPort": "443",
             "ToPort": "443",
             "IpProtocol": "tcp",
@@ -232,11 +230,9 @@
         },
         "Type": "AWS::EC2::SecurityGroupEgress"
     },
-    "TestVPCVPCEndpointsSubnetIngressTestVPCSecurityGroup": {
+    "TestVPCVPCEndpointsSubnetIngressFromVPC": {
         "Properties": {
-            "SourceSecurityGroupId": {
-                "Ref": "TestVPCSecurityGroup"
-            },
+            "CidrIp": "10.10.0.0/16",
             "FromPort": "443",
             "ToPort": "443",
             "IpProtocol": "tcp",


### PR DESCRIPTION
Change VPC endpoints security group rules to Authorize HTTPS from and to all VPC IPs instead of limiting inbound/outbound from/to the default VPC security group.
There was no rational limitating which VPC security groups can access VPC endpoints. If we want to disable VPC endpoints for a given security group this can be achieved with its own outbound rules.