### PR TITLE
Add property to get Version attribute of a Version

### DIFF
--- a/src/e3/aws/troposphere/awslambda/__init__.py
+++ b/src/e3/aws/troposphere/awslambda/__init__.py
@@ -572,13 +572,13 @@ class Version(Construct):
         self.code_sha256 = code_sha256
 
     @property
-    def arn(self) -> GetAtt:
-        """Arn of the lambda version."""
-        return GetAtt(name_to_id(self.name), "Arn")
-
-    @property
     def ref(self) -> Ref:
         return Ref(name_to_id(self.name))
+
+    @property
+    def version(self) -> GetAtt:
+        """Version of the lambda version."""
+        return GetAtt(name_to_id(self.name), "Version")
 
     def resources(self, stack: Stack) -> list[AWSObject]:
         """Return list of AWSObject associated with the construct."""

--- a/tests/tests_e3_aws/troposphere/awslambda/awslambda_test.py
+++ b/tests/tests_e3_aws/troposphere/awslambda/awslambda_test.py
@@ -185,12 +185,12 @@ EXPECTED_ALIAS_TEMPLATE = {
             "Name": "myalias",
             "Description": "this is a test",
             "FunctionName": {"Fn::GetAtt": ["Mypylambda", "Arn"]},
-            "FunctionVersion": {"Fn::GetAtt": ["Newversion", "Arn"]},
+            "FunctionVersion": {"Fn::GetAtt": ["Newversion", "Version"]},
             "ProvisionedConcurrencyConfig": {"ProvisionedConcurrentExecutions": 1},
             "RoutingConfig": {
                 "AdditionalVersionWeights": [
                     {
-                        "FunctionVersion": {"Fn::GetAtt": ["Oldversion", "Arn"]},
+                        "FunctionVersion": {"Fn::GetAtt": ["Oldversion", "Version"]},
                         "FunctionWeight": 0.5,
                     }
                 ]
@@ -399,13 +399,15 @@ def test_alias(stack: Stack, simple_lambda_function: PyFunction) -> None:
             name="myalias",
             description="this is a test",
             lambda_arn=simple_lambda_function.arn,
-            lambda_version=new_version.arn,
+            lambda_version=new_version.version,
             provisioned_concurrency_config=ProvisionedConcurrencyConfiguration(
                 ProvisionedConcurrentExecutions=1
             ),
             routing_config=AliasRoutingConfiguration(
                 AdditionalVersionWeights=[
-                    VersionWeight(FunctionVersion=old_version.arn, FunctionWeight=0.5)
+                    VersionWeight(
+                        FunctionVersion=old_version.version, FunctionWeight=0.5
+                    )
                 ]
             ),
         )


### PR DESCRIPTION
The class awslambda.Version is missing a property to get its Version attribute.
awslambda_test.py was also updated as the lambda_version parameter expects the Version attribute instead of the Arn attribute.
Also remove the arn property as AWS:Lambda:Version doesn't have an Arn attribute