### PR TITLE
Improve the names given to versions in AutoVersion

### DIFF
--- a/src/e3/aws/troposphere/awslambda/__init__.py
+++ b/src/e3/aws/troposphere/awslambda/__init__.py
@@ -641,7 +641,7 @@ class AutoVersion(Construct):
         self.lambda_arn = lambda_function.arn if lambda_function else lambda_arn
         self.versions = [
             Version(
-                name=f"{self.lambda_name}Version{i}",
+                name=f"{self.lambda_name}-v{i}",
                 description=f"version {i} of {self.lambda_name} lambda",
                 lambda_arn=self.lambda_arn,
             )

--- a/tests/tests_e3_aws/troposphere/awslambda/awslambda_test.py
+++ b/tests/tests_e3_aws/troposphere/awslambda/awslambda_test.py
@@ -203,14 +203,14 @@ EXPECTED_ALIAS_TEMPLATE = {
 }
 
 EXPECTED_AUTOVERSION_DEFAULT_TEMPLATE = {
-    "MypylambdaVersion1": {
+    "MypylambdaV1": {
         "Properties": {
             "Description": "version 1 of mypylambda lambda",
             "FunctionName": {"Fn::GetAtt": ["Mypylambda", "Arn"]},
         },
         "Type": "AWS::Lambda::Version",
     },
-    "MypylambdaVersion2": {
+    "MypylambdaV2": {
         "Properties": {
             "Description": "version 2 of mypylambda lambda",
             "FunctionName": {"Fn::GetAtt": ["Mypylambda", "Arn"]},
@@ -220,7 +220,7 @@ EXPECTED_AUTOVERSION_DEFAULT_TEMPLATE = {
 }
 
 EXPECTED_AUTOVERSION_SINGLE_TEMPLATE = {
-    "MypylambdaVersion1": {
+    "MypylambdaV1": {
         "Properties": {
             "Description": "version 1 of mypylambda lambda",
             "FunctionName": {"Fn::GetAtt": ["Mypylambda", "Arn"]},
@@ -230,14 +230,14 @@ EXPECTED_AUTOVERSION_SINGLE_TEMPLATE = {
 }
 
 EXPECTED_AUTOVERSION_TEMPLATE = {
-    "MypylambdaVersion2": {
+    "MypylambdaV2": {
         "Properties": {
             "Description": "version 2 of mypylambda lambda",
             "FunctionName": {"Fn::GetAtt": ["Mypylambda", "Arn"]},
         },
         "Type": "AWS::Lambda::Version",
     },
-    "MypylambdaVersion3": {
+    "MypylambdaV3": {
         "Properties": {
             "Description": "version 3 of mypylambda lambda",
             "FunctionName": {"Fn::GetAtt": ["Mypylambda", "Arn"]},
@@ -474,8 +474,8 @@ def test_autoversion_default(stack: Stack, simple_lambda_function: PyFunction) -
     stack.add(auto_version)
     print(stack.export()["Resources"])
     assert stack.export()["Resources"] == EXPECTED_AUTOVERSION_DEFAULT_TEMPLATE
-    assert auto_version.previous.name == "mypylambdaVersion1"
-    assert auto_version.latest.name == "mypylambdaVersion2"
+    assert auto_version.previous.name == "mypylambda-v1"
+    assert auto_version.latest.name == "mypylambda-v2"
 
 
 def test_autoversion_single(stack: Stack, simple_lambda_function: PyFunction) -> None:
@@ -487,8 +487,8 @@ def test_autoversion_single(stack: Stack, simple_lambda_function: PyFunction) ->
     stack.add(auto_version)
     print(stack.export()["Resources"])
     assert stack.export()["Resources"] == EXPECTED_AUTOVERSION_SINGLE_TEMPLATE
-    assert auto_version.previous.name == "mypylambdaVersion1"
-    assert auto_version.latest.name == "mypylambdaVersion1"
+    assert auto_version.previous.name == "mypylambda-v1"
+    assert auto_version.latest.name == "mypylambda-v1"
 
 
 def test_autoversion(stack: Stack, simple_lambda_function: PyFunction) -> None:
@@ -506,5 +506,5 @@ def test_autoversion(stack: Stack, simple_lambda_function: PyFunction) -> None:
     stack.add(auto_version)
     print(stack.export()["Resources"])
     assert stack.export()["Resources"] == EXPECTED_AUTOVERSION_TEMPLATE
-    assert auto_version.previous.name == "mypylambdaVersion2"
-    assert auto_version.latest.name == "mypylambdaVersion3"
+    assert auto_version.previous.name == "mypylambda-v2"
+    assert auto_version.latest.name == "mypylambda-v3"


### PR DESCRIPTION
Currently AutoVersion assigns the names {lambda_name}Version{i} to generated versions while we more commonly use names with dashes that are later converted to ids for AWS