### PR TITLE
Add a way to configure multiple HTTP API stages

### DIFF
--- a/tests/tests_e3_aws/troposphere/apigateway_test.py
+++ b/tests/tests_e3_aws/troposphere/apigateway_test.py
@@ -2,12 +2,24 @@ from __future__ import annotations
 import json
 import os
 from e3.aws.troposphere import Stack
-from e3.aws.troposphere.awslambda import Py38Function
-from e3.aws.troposphere.apigateway import JWT_AUTH, HttpApi, GET, POST
+from e3.aws.troposphere.awslambda import (
+    Py38Function,
+    BlueGreenAliases,
+    BlueGreenAliasConfiguration,
+    AutoVersion,
+)
+from e3.aws.troposphere.apigateway import (
+    JWT_AUTH,
+    HttpApi,
+    GET,
+    POST,
+    StageConfiguration,
+)
 
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 
-EXPECTED_TEMPLATE = {
+# Generic template without any stage
+COMMON_TEMPLATE = {
     "Mypylambda": {
         "Properties": {
             "Code": {
@@ -36,30 +48,6 @@ EXPECTED_TEMPLATE = {
         },
         "Type": "AWS::ApiGatewayV2::Api",
     },
-    "TestapiDefaultStage": {
-        "Properties": {
-            "AccessLogSettings": {
-                "DestinationArn": {"Fn::GetAtt": ["TestapiLogGroup", "Arn"]},
-                "Format": '{"source_ip": "$context.identity.sourceIp", '
-                '"request_time": "$context.requestTime", '
-                '"method": "$context.httpMethod", "route": "$context.routeKey", '
-                '"protocol": "$context.protocol", "status": "$context.status", '
-                '"response_length": "$context.responseLength", '
-                '"request_id": "$context.requestId", '
-                '"integration_error_msg": "$context.integrationErrorMessage"}',
-            },
-            "ApiId": {"Ref": "Testapi"},
-            "AutoDeploy": True,
-            "Description": "stage $default",
-            "DefaultRouteSettings": {
-                "DetailedMetricsEnabled": True,
-                "ThrottlingBurstLimit": 10,
-                "ThrottlingRateLimit": 10,
-            },
-            "StageName": "$default",
-        },
-        "Type": "AWS::ApiGatewayV2::Stage",
-    },
     "TestapiIntegration": {
         "Properties": {
             "ApiId": {"Ref": "Testapi"},
@@ -83,6 +71,46 @@ EXPECTED_TEMPLATE = {
         },
         "Type": "AWS::ApiGatewayV2::Route",
     },
+    "TestapiPOSTapi2Route": {
+        "Properties": {
+            "ApiId": {"Ref": "Testapi"},
+            "AuthorizationType": "NONE",
+            "RouteKey": "POST /api2",
+            "Target": {
+                "Fn::Sub": [
+                    "integrations/${integration}",
+                    {"integration": {"Ref": "TestapiIntegration"}},
+                ]
+            },
+        },
+        "Type": "AWS::ApiGatewayV2::Route",
+    },
+}
+
+# Generic stage template with common values
+COMMON_STAGE_TEMPLATE = {
+    "AccessLogSettings": {
+        "DestinationArn": {"Fn::GetAtt": ["TestapiLogGroup", "Arn"]},
+        "Format": '{"source_ip": "$context.identity.sourceIp", '
+        '"request_time": "$context.requestTime", '
+        '"method": "$context.httpMethod", "route": "$context.routeKey", '
+        '"protocol": "$context.protocol", "status": "$context.status", '
+        '"response_length": "$context.responseLength", '
+        '"request_id": "$context.requestId", '
+        '"integration_error_msg": "$context.integrationErrorMessage"}',
+    },
+    "ApiId": {"Ref": "Testapi"},
+    "AutoDeploy": True,
+    "DefaultRouteSettings": {
+        "DetailedMetricsEnabled": True,
+        "ThrottlingBurstLimit": 10,
+        "ThrottlingRateLimit": 10,
+    },
+}
+
+# API with a $default stage
+EXPECTED_TEMPLATE = {
+    **COMMON_TEMPLATE,
     "TestapiGETapi1LambdaPermission": {
         "Properties": {
             "Action": "lambda:InvokeFunction",
@@ -97,20 +125,6 @@ EXPECTED_TEMPLATE = {
             },
         },
         "Type": "AWS::Lambda::Permission",
-    },
-    "TestapiPOSTapi2Route": {
-        "Properties": {
-            "ApiId": {"Ref": "Testapi"},
-            "AuthorizationType": "NONE",
-            "RouteKey": "POST /api2",
-            "Target": {
-                "Fn::Sub": [
-                    "integrations/${integration}",
-                    {"integration": {"Ref": "TestapiIntegration"}},
-                ]
-            },
-        },
-        "Type": "AWS::ApiGatewayV2::Route",
     },
     "TestapiPOSTapi2LambdaPermission": {
         "Properties": {
@@ -127,66 +141,148 @@ EXPECTED_TEMPLATE = {
         },
         "Type": "AWS::Lambda::Permission",
     },
-}
-
-EXPECTED_TEMPLATE_STAGE = {
-    **EXPECTED_TEMPLATE,
-    **{
-        "TestapiTestStage": {
-            "Properties": {
-                "AccessLogSettings": {
-                    "DestinationArn": {"Fn::GetAtt": ["TestapiLogGroup", "Arn"]},
-                    "Format": '{"source_ip": "$context.identity.sourceIp", '
-                    '"request_time": "$context.requestTime", '
-                    '"method": "$context.httpMethod", "route": "$context.routeKey", '
-                    '"protocol": "$context.protocol", "status": "$context.status", '
-                    '"response_length": "$context.responseLength", '
-                    '"request_id": "$context.requestId", '
-                    '"integration_error_msg": "$context.integrationErrorMessage"}',
-                },
-                "ApiId": {"Ref": "Testapi"},
-                "AutoDeploy": True,
-                "DefaultRouteSettings": {
-                    "DetailedMetricsEnabled": True,
-                    "ThrottlingBurstLimit": 10,
-                    "ThrottlingRateLimit": 10,
-                },
-                "Description": "stage test",
-                "StageName": "test",
-                "StageVariables": {"somevar": "somevalue"},
-            },
-            "Type": "AWS::ApiGatewayV2::Stage",
-        }
+    "TestapiDefaultStage": {
+        "Properties": {
+            **COMMON_STAGE_TEMPLATE,
+            "Description": "stage $default",
+            "StageName": "$default",
+        },
+        "Type": "AWS::ApiGatewayV2::Stage",
     },
 }
 
-EXPECTED_TEMPLATE_LAMBDA_ALIAS = {
+# API with $default/beta stages
+EXPECTED_TEMPLATE_STAGE = {
     **EXPECTED_TEMPLATE,
-    **{
-        "TestapiDefaultStage": {
-            "Properties": {
-                **EXPECTED_TEMPLATE_STAGE["TestapiDefaultStage"]["Properties"],
-                **{"StageVariables": {"lambdaAlias": "prod"}},
+    "TestapiGETapi1BetaLambdaPermission": {
+        "Properties": {
+            "Action": "lambda:InvokeFunction",
+            "FunctionName": {"Ref": "Mypylambda"},
+            "Principal": "apigateway.amazonaws.com",
+            "SourceArn": {
+                "Fn::Sub": [
+                    "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:"
+                    "${api}/beta/${route_arn}",
+                    {"api": {"Ref": "Testapi"}, "route_arn": "GET/api1"},
+                ]
             },
-            "Type": "AWS::ApiGatewayV2::Stage",
         },
-        "TestapiTestStage": {
-            "Properties": {
-                **EXPECTED_TEMPLATE_STAGE["TestapiTestStage"]["Properties"],
-                **{"StageVariables": {"lambdaAlias": "test"}},
+        "Type": "AWS::Lambda::Permission",
+    },
+    "TestapiPOSTapi2BetaLambdaPermission": {
+        "Properties": {
+            "Action": "lambda:InvokeFunction",
+            "FunctionName": {"Ref": "Mypylambda"},
+            "Principal": "apigateway.amazonaws.com",
+            "SourceArn": {
+                "Fn::Sub": [
+                    "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:"
+                    "${api}/beta/${route_arn}",
+                    {"api": {"Ref": "Testapi"}, "route_arn": "POST/api2"},
+                ]
             },
-            "Type": "AWS::ApiGatewayV2::Stage",
         },
-        "TestapiIntegration": {
-            "Properties": {
-                **EXPECTED_TEMPLATE_STAGE["TestapiIntegration"]["Properties"],
-                **{
-                    "IntegrationUri": "arn:aws:lambda:eu-west-1:123456789012:function:"
-                    "mypylambda:${stageVariables.lambdaAlias}"
-                },
+        "Type": "AWS::Lambda::Permission",
+    },
+    "TestapiBetaStage": {
+        "Properties": {
+            **COMMON_STAGE_TEMPLATE,
+            "Description": "stage beta",
+            "StageName": "beta",
+            "StageVariables": {"somevar": "somevalue"},
+        },
+        "Type": "AWS::ApiGatewayV2::Stage",
+    },
+}
+
+# API with $default/beta stages and lambdaAlias variable
+EXPECTED_TEMPLATE_LAMBDA_ALIAS = {
+    **COMMON_TEMPLATE,
+    "TestapiGETapi1LambdaPermission": {
+        "Properties": {
+            "Action": "lambda:InvokeFunction",
+            "FunctionName": {"Ref": "MypylambdaBlueAlias"},
+            "Principal": "apigateway.amazonaws.com",
+            "SourceArn": {
+                "Fn::Sub": [
+                    "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:"
+                    "${api}/$default/${route_arn}",
+                    {"api": {"Ref": "Testapi"}, "route_arn": "GET/api1"},
+                ]
             },
-            "Type": "AWS::ApiGatewayV2::Integration",
         },
+        "Type": "AWS::Lambda::Permission",
+    },
+    "TestapiPOSTapi2LambdaPermission": {
+        "Properties": {
+            "Action": "lambda:InvokeFunction",
+            "FunctionName": {"Ref": "MypylambdaBlueAlias"},
+            "Principal": "apigateway.amazonaws.com",
+            "SourceArn": {
+                "Fn::Sub": [
+                    "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:"
+                    "${api}/$default/${route_arn}",
+                    {"api": {"Ref": "Testapi"}, "route_arn": "POST/api2"},
+                ]
+            },
+        },
+        "Type": "AWS::Lambda::Permission",
+    },
+    "TestapiGETapi1BetaLambdaPermission": {
+        "Properties": {
+            "Action": "lambda:InvokeFunction",
+            "FunctionName": {"Ref": "MypylambdaGreenAlias"},
+            "Principal": "apigateway.amazonaws.com",
+            "SourceArn": {
+                "Fn::Sub": [
+                    "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:"
+                    "${api}/beta/${route_arn}",
+                    {"api": {"Ref": "Testapi"}, "route_arn": "GET/api1"},
+                ]
+            },
+        },
+        "Type": "AWS::Lambda::Permission",
+    },
+    "TestapiPOSTapi2BetaLambdaPermission": {
+        "Properties": {
+            "Action": "lambda:InvokeFunction",
+            "FunctionName": {"Ref": "MypylambdaGreenAlias"},
+            "Principal": "apigateway.amazonaws.com",
+            "SourceArn": {
+                "Fn::Sub": [
+                    "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:"
+                    "${api}/beta/${route_arn}",
+                    {"api": {"Ref": "Testapi"}, "route_arn": "POST/api2"},
+                ]
+            },
+        },
+        "Type": "AWS::Lambda::Permission",
+    },
+    "TestapiDefaultStage": {
+        "Properties": {
+            **COMMON_STAGE_TEMPLATE,
+            "Description": "stage $default",
+            "StageName": "$default",
+            "StageVariables": {"lambdaAlias": "MypylambdaBlueAlias"},
+        },
+        "Type": "AWS::ApiGatewayV2::Stage",
+    },
+    "TestapiBetaStage": {
+        "Properties": {
+            **COMMON_STAGE_TEMPLATE,
+            "Description": "stage beta",
+            "StageName": "beta",
+            "StageVariables": {"lambdaAlias": "MypylambdaGreenAlias"},
+        },
+        "Type": "AWS::ApiGatewayV2::Stage",
+    },
+    "TestapiIntegration": {
+        "Properties": {
+            **EXPECTED_TEMPLATE["TestapiIntegration"]["Properties"],
+            "IntegrationUri": "arn:aws:lambda:eu-west-1:123456789012:function:"
+            "mypylambda:${stageVariables.lambdaAlias}",
+        },
+        "Type": "AWS::ApiGatewayV2::Integration",
     },
 }
 
@@ -234,17 +330,14 @@ def test_http_api_stage(stack: Stack) -> None:
         description="this is a test",
         lambda_arn=lambda_fun.ref,
         route_list=[GET(route="/api1"), POST(route="/api2")],
+        stages_config=[
+            StageConfiguration("$default"),
+            StageConfiguration("beta", variables={"somevar": "somevalue"}),
+        ],
     )
 
     stack.add(lambda_fun)
     stack.add(http_api)
-    stack.add(
-        http_api.declare_stage(
-            stage_name="test",
-            log_arn="unused",
-            stage_variables={"somevar": "somevalue"},
-        )
-    )
 
     assert stack.export()["Resources"] == EXPECTED_TEMPLATE_STAGE
 
@@ -262,25 +355,41 @@ def test_http_api_lambda_alias(stack: Stack) -> None:
         handler="app.main",
     )
 
+    lambda_versions = AutoVersion(2, lambda_function=lambda_fun)
+
+    lambda_aliases = BlueGreenAliases(
+        blue_config=BlueGreenAliasConfiguration(
+            version=lambda_versions.previous.version
+        ),
+        green_config=BlueGreenAliasConfiguration(
+            version=lambda_versions.latest.version
+        ),
+        lambda_function=lambda_fun,
+    )
+
     http_api = HttpApi(
         name="testapi",
         description="this is a test",
         lambda_arn=lambda_fun.ref,
         route_list=[GET(route="/api1"), POST(route="/api2")],
-        stage_variables={"lambdaAlias": "prod"},
+        stages_config=[
+            StageConfiguration(
+                "$default",
+                lambda_arn_permission=lambda_aliases.blue.ref,
+                variables={"lambdaAlias": lambda_aliases.blue.name},
+            ),
+            StageConfiguration(
+                "beta",
+                lambda_arn_permission=lambda_aliases.green.ref,
+                variables={"lambdaAlias": lambda_aliases.green.name},
+            ),
+        ],
         integration_uri="arn:aws:lambda:eu-west-1:123456789012:function:"
         f"{lambda_fun.name}:${{stageVariables.lambdaAlias}}",
     )
 
     stack.add(lambda_fun)
     stack.add(http_api)
-    stack.add(
-        http_api.declare_stage(
-            stage_name="test",
-            log_arn="unused",
-            stage_variables={"lambdaAlias": "test"},
-        )
-    )
 
     assert stack.export()["Resources"] == EXPECTED_TEMPLATE_LAMBDA_ALIAS
 
@@ -318,6 +427,51 @@ def test_http_api_custom_domain(stack: Stack) -> None:
     stack.add(http_api)
 
     with open(os.path.join(TEST_DIR, "apigateway_test_custom_domain.json")) as fd:
+        expected = json.load(fd)
+
+    print(stack.export()["Resources"])
+    assert stack.export()["Resources"] == expected
+
+
+def test_http_api_custom_domain_stages(stack: Stack) -> None:
+    """Test basic HTTP API with custom domain and stage."""
+    stack.s3_bucket = "cfn_bucket"
+    stack.s3_key = "templates/"
+
+    lambda_fun = Py38Function(
+        name="mypylambda",
+        description="this is a test",
+        role="somearn",
+        code_dir="my_code_dir",
+        handler="app.main",
+    )
+    stack.add(lambda_fun)
+    http_api = HttpApi(
+        name="testapi",
+        description="this is a test",
+        lambda_arn=lambda_fun.ref,
+        domain_name="api.example.com",
+        hosted_zone_id="ABCDEFG",
+        route_list=[
+            GET(route="/api1"),
+            POST(route="/api2"),
+            GET("/api3", auth=JWT_AUTH, authorizer_name="testauthorizer"),
+        ],
+        stages_config=[
+            StageConfiguration("$default"),
+            StageConfiguration("beta", api_mapping_key="beta"),
+        ],
+    )
+    http_api.add_jwt_authorizer(
+        name="testauthorizer",
+        audience=["testaudience"],
+        issuer="https://cognito-idp.eu-west-1.amazonaws.com/eu-west-1_test",
+    )
+    stack.add(http_api)
+
+    with open(
+        os.path.join(TEST_DIR, "apigateway_test_custom_domain_stages.json")
+    ) as fd:
         expected = json.load(fd)
 
     print(stack.export()["Resources"])

--- a/tests/tests_e3_aws/troposphere/apigateway_test.py
+++ b/tests/tests_e3_aws/troposphere/apigateway_test.py
@@ -3,7 +3,7 @@ import json
 import os
 from e3.aws.troposphere import Stack
 from e3.aws.troposphere.awslambda import (
-    Py38Function,
+    PyFunction,
     BlueGreenAliases,
     BlueGreenAliasConfiguration,
     AutoVersion,
@@ -292,12 +292,14 @@ def test_http_api(stack: Stack) -> None:
     stack.s3_bucket = "cfn_bucket"
     stack.s3_key = "templates/"
 
-    lambda_fun = Py38Function(
+    lambda_fun = PyFunction(
         name="mypylambda",
         description="this is a test",
         role="somearn",
         code_dir="my_code_dir",
         handler="app.main",
+        runtime="python3.8",
+        logs_retention_in_days=None,
     )
     stack.add(lambda_fun)
     stack.add(
@@ -317,12 +319,14 @@ def test_http_api_stage(stack: Stack) -> None:
     stack.s3_bucket = "cfn_bucket"
     stack.s3_key = "templates/"
 
-    lambda_fun = Py38Function(
+    lambda_fun = PyFunction(
         name="mypylambda",
         description="this is a test",
         role="somearn",
         code_dir="my_code_dir",
         handler="app.main",
+        runtime="python3.8",
+        logs_retention_in_days=None,
     )
 
     http_api = HttpApi(
@@ -347,12 +351,14 @@ def test_http_api_lambda_alias(stack: Stack) -> None:
     stack.s3_bucket = "cfn_bucket"
     stack.s3_key = "templates/"
 
-    lambda_fun = Py38Function(
+    lambda_fun = PyFunction(
         name="mypylambda",
         description="this is a test",
         role="somearn",
         code_dir="my_code_dir",
         handler="app.main",
+        runtime="python3.8",
+        logs_retention_in_days=None,
     )
 
     lambda_versions = AutoVersion(2, lambda_function=lambda_fun)
@@ -399,12 +405,14 @@ def test_http_api_custom_domain(stack: Stack) -> None:
     stack.s3_bucket = "cfn_bucket"
     stack.s3_key = "templates/"
 
-    lambda_fun = Py38Function(
+    lambda_fun = PyFunction(
         name="mypylambda",
         description="this is a test",
         role="somearn",
         code_dir="my_code_dir",
         handler="app.main",
+        runtime="python3.8",
+        logs_retention_in_days=None,
     )
     stack.add(lambda_fun)
     http_api = HttpApi(
@@ -438,12 +446,14 @@ def test_http_api_custom_domain_stages(stack: Stack) -> None:
     stack.s3_bucket = "cfn_bucket"
     stack.s3_key = "templates/"
 
-    lambda_fun = Py38Function(
+    lambda_fun = PyFunction(
         name="mypylambda",
         description="this is a test",
         role="somearn",
         code_dir="my_code_dir",
         handler="app.main",
+        runtime="python3.8",
+        logs_retention_in_days=None,
     )
     stack.add(lambda_fun)
     http_api = HttpApi(

--- a/tests/tests_e3_aws/troposphere/apigateway_test_custom_domain_stages.json
+++ b/tests/tests_e3_aws/troposphere/apigateway_test_custom_domain_stages.json
@@ -1,0 +1,381 @@
+{
+  "Mypylambda": {
+    "Properties": {
+      "Code": {
+        "S3Bucket": "cfn_bucket",
+        "S3Key": "templates/mypylambda_lambda.zip"
+      },
+      "Timeout": 3,
+      "Description": "this is a test",
+      "Role": "somearn",
+      "FunctionName": "mypylambda",
+      "Runtime": "python3.8",
+      "Handler": "app.main"
+    },
+    "Type": "AWS::Lambda::Function"
+  },
+  "TestapiLogGroup": {
+    "Properties": {
+      "LogGroupName": "testapi"
+    },
+    "Type": "AWS::Logs::LogGroup"
+  },
+  "Testapi": {
+    "Properties": {
+      "Description": "this is a test",
+      "ProtocolType": "HTTP",
+      "Name": "testapi",
+      "DisableExecuteApiEndpoint": true
+    },
+    "Type": "AWS::ApiGatewayV2::Api"
+  },
+  "TestapiDefaultStage": {
+    "Properties": {
+      "AccessLogSettings": {
+        "DestinationArn": {
+          "Fn::GetAtt": [
+            "TestapiLogGroup",
+            "Arn"
+          ]
+        },
+        "Format": "{\"source_ip\": \"$context.identity.sourceIp\", \"request_time\": \"$context.requestTime\", \"method\": \"$context.httpMethod\", \"route\": \"$context.routeKey\", \"protocol\": \"$context.protocol\", \"status\": \"$context.status\", \"response_length\": \"$context.responseLength\", \"request_id\": \"$context.requestId\", \"integration_error_msg\": \"$context.integrationErrorMessage\"}"
+      },
+      "ApiId": {
+        "Ref": "Testapi"
+      },
+      "AutoDeploy": true,
+      "Description": "stage $default",
+      "DefaultRouteSettings": {
+        "DetailedMetricsEnabled": true,
+        "ThrottlingBurstLimit": 10,
+        "ThrottlingRateLimit": 10
+      },
+      "StageName": "$default"
+    },
+    "Type": "AWS::ApiGatewayV2::Stage"
+  },
+  "TestapiIntegration": {
+    "Properties": {
+      "ApiId": {
+        "Ref": "Testapi"
+      },
+      "IntegrationType": "AWS_PROXY",
+      "IntegrationUri": {
+        "Ref": "Mypylambda"
+      },
+      "PayloadFormatVersion": "2.0"
+    },
+    "Type": "AWS::ApiGatewayV2::Integration"
+  },
+  "TestapiGETapi1Route": {
+    "Properties": {
+      "ApiId": {
+        "Ref": "Testapi"
+      },
+      "AuthorizationType": "NONE",
+      "RouteKey": "GET /api1",
+      "Target": {
+        "Fn::Sub": [
+          "integrations/${integration}",
+          {
+            "integration": {
+              "Ref": "TestapiIntegration"
+            }
+          }
+        ]
+      }
+    },
+    "Type": "AWS::ApiGatewayV2::Route"
+  },
+  "TestapiGETapi1LambdaPermission": {
+    "Properties": {
+      "Action": "lambda:InvokeFunction",
+      "FunctionName": {
+        "Ref": "Mypylambda"
+      },
+      "Principal": "apigateway.amazonaws.com",
+      "SourceArn": {
+        "Fn::Sub": [
+          "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${api}/$default/${route_arn}",
+          {
+            "api": {
+              "Ref": "Testapi"
+            },
+            "route_arn": "GET/api1"
+          }
+        ]
+      }
+    },
+    "Type": "AWS::Lambda::Permission"
+  },
+  "TestapiPOSTapi2Route": {
+    "Properties": {
+      "ApiId": {
+        "Ref": "Testapi"
+      },
+      "AuthorizationType": "NONE",
+      "RouteKey": "POST /api2",
+      "Target": {
+        "Fn::Sub": [
+          "integrations/${integration}",
+          {
+            "integration": {
+              "Ref": "TestapiIntegration"
+            }
+          }
+        ]
+      }
+    },
+    "Type": "AWS::ApiGatewayV2::Route"
+  },
+  "TestapiGETapi1BetaLambdaPermission": {
+    "Properties": {
+      "Action": "lambda:InvokeFunction",
+      "FunctionName": {
+        "Ref": "Mypylambda"
+      },
+      "Principal": "apigateway.amazonaws.com",
+      "SourceArn": {
+        "Fn::Sub": [
+          "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${api}/beta/${route_arn}",
+          {
+            "api": {
+              "Ref": "Testapi"
+            },
+            "route_arn": "GET/api1"
+          }
+        ]
+      }
+    },
+    "Type": "AWS::Lambda::Permission"
+  },
+  "TestapiGETapi3BetaLambdaPermission": {
+    "Properties": {
+      "Action": "lambda:InvokeFunction",
+      "FunctionName": {
+        "Ref": "Mypylambda"
+      },
+      "Principal": "apigateway.amazonaws.com",
+      "SourceArn": {
+        "Fn::Sub": [
+          "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${api}/beta/${route_arn}",
+          {
+            "api": {
+              "Ref": "Testapi"
+            },
+            "route_arn": "GET/api3"
+          }
+        ]
+      }
+    },
+    "Type": "AWS::Lambda::Permission"
+  },
+  "TestapiPOSTapi2BetaLambdaPermission": {
+    "Properties": {
+      "Action": "lambda:InvokeFunction",
+      "FunctionName": {
+        "Ref": "Mypylambda"
+      },
+      "Principal": "apigateway.amazonaws.com",
+      "SourceArn": {
+        "Fn::Sub": [
+          "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${api}/beta/${route_arn}",
+          {
+            "api": {
+              "Ref": "Testapi"
+            },
+            "route_arn": "POST/api2"
+          }
+        ]
+      }
+    },
+    "Type": "AWS::Lambda::Permission"
+  },
+  "TestapiBetaStage": {
+    "Properties": {
+      "AccessLogSettings": {
+        "DestinationArn": {
+          "Fn::GetAtt": [
+            "TestapiLogGroup",
+            "Arn"
+          ]
+        },
+        "Format": "{\"source_ip\": \"$context.identity.sourceIp\", \"request_time\": \"$context.requestTime\", \"method\": \"$context.httpMethod\", \"route\": \"$context.routeKey\", \"protocol\": \"$context.protocol\", \"status\": \"$context.status\", \"response_length\": \"$context.responseLength\", \"request_id\": \"$context.requestId\", \"integration_error_msg\": \"$context.integrationErrorMessage\"}"
+      },
+      "ApiId": {
+        "Ref": "Testapi"
+      },
+      "AutoDeploy": true,
+      "DefaultRouteSettings": {
+        "DetailedMetricsEnabled": true,
+        "ThrottlingBurstLimit": 10,
+        "ThrottlingRateLimit": 10
+      },
+      "Description": "stage beta",
+      "StageName": "beta"
+    },
+    "Type": "AWS::ApiGatewayV2::Stage"
+  },
+  "TestapiPOSTapi2LambdaPermission": {
+    "Properties": {
+      "Action": "lambda:InvokeFunction",
+      "FunctionName": {
+        "Ref": "Mypylambda"
+      },
+      "Principal": "apigateway.amazonaws.com",
+      "SourceArn": {
+        "Fn::Sub": [
+          "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${api}/$default/${route_arn}",
+          {
+            "api": {
+              "Ref": "Testapi"
+            },
+            "route_arn": "POST/api2"
+          }
+        ]
+      }
+    },
+    "Type": "AWS::Lambda::Permission"
+  },
+  "TestapiGETapi3Route": {
+    "Properties": {
+      "ApiId": {
+        "Ref": "Testapi"
+      },
+      "AuthorizationType": "JWT",
+      "RouteKey": "GET /api3",
+      "Target": {
+        "Fn::Sub": [
+          "integrations/${integration}",
+          {
+            "integration": {
+              "Ref": "TestapiIntegration"
+            }
+          }
+        ]
+      },
+      "AuthorizerId": {
+        "Ref": "Testauthorizer"
+      }
+    },
+    "Type": "AWS::ApiGatewayV2::Route"
+  },
+  "TestapiGETapi3LambdaPermission": {
+    "Properties": {
+      "Action": "lambda:InvokeFunction",
+      "FunctionName": {
+        "Ref": "Mypylambda"
+      },
+      "Principal": "apigateway.amazonaws.com",
+      "SourceArn": {
+        "Fn::Sub": [
+          "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${api}/$default/${route_arn}",
+          {
+            "api": {
+              "Ref": "Testapi"
+            },
+            "route_arn": "GET/api3"
+          }
+        ]
+      }
+    },
+    "Type": "AWS::Lambda::Permission"
+  },
+  "TestapiapiexamplecomCertificate": {
+    "Properties": {
+      "DomainName": "api.example.com",
+      "DomainValidationOptions": [
+        {
+          "DomainName": "api.example.com",
+          "HostedZoneId": "ABCDEFG"
+        }
+      ],
+      "ValidationMethod": "DNS"
+    },
+    "Type": "AWS::CertificateManager::Certificate"
+  },
+  "TestapiapiexamplecomDomain": {
+    "Properties": {
+      "DomainName": "api.example.com",
+      "DomainNameConfigurations": [
+        {
+          "CertificateArn": {
+            "Ref": "TestapiapiexamplecomCertificate"
+          }
+        }
+      ]
+    },
+    "Type": "AWS::ApiGatewayV2::DomainName"
+  },
+  "TestapiapiexamplecomApiMapping": {
+    "Properties": {
+      "DomainName": {
+        "Ref": "TestapiapiexamplecomDomain"
+      },
+      "ApiId": {
+        "Ref": "Testapi"
+      },
+      "Stage": {
+        "Ref": "TestapiDefaultStage"
+      }
+    },
+    "Type": "AWS::ApiGatewayV2::ApiMapping"
+  },
+  "TestapiapiexamplecomBetaApiMapping": {
+    "Properties": {
+      "ApiId": {
+        "Ref": "Testapi"
+      },
+      "ApiMappingKey": "beta",
+      "DomainName": {
+        "Ref": "TestapiapiexamplecomDomain"
+      },
+      "Stage": {
+        "Ref": "TestapiBetaStage"
+      }
+    },
+    "Type": "AWS::ApiGatewayV2::ApiMapping"
+  },
+  "TestapiapiexamplecomDNS": {
+    "Properties": {
+      "Name": "api.example.com",
+      "Type": "A",
+      "HostedZoneId": "ABCDEFG",
+      "AliasTarget": {
+        "DNSName": {
+          "Fn::GetAtt": [
+            "TestapiapiexamplecomDomain",
+            "RegionalDomainName"
+          ]
+        },
+        "HostedZoneId": {
+          "Fn::GetAtt": [
+            "TestapiapiexamplecomDomain",
+            "RegionalHostedZoneId"
+          ]
+        },
+        "EvaluateTargetHealth": false
+      }
+    },
+    "Type": "AWS::Route53::RecordSet"
+  },
+  "Testauthorizer": {
+    "Properties": {
+      "ApiId": {
+        "Ref": "Testapi"
+      },
+      "AuthorizerType": "JWT",
+      "Name": "testauthorizer",
+      "IdentitySource": [
+        "$request.header.Authorization"
+      ],
+      "JwtConfiguration": {
+        "Audience": [
+          "testaudience"
+        ],
+        "Issuer": "https://cognito-idp.eu-west-1.amazonaws.com/eu-west-1_test"
+      }
+    },
+    "Type": "AWS::ApiGatewayV2::Authorizer"
+  }
+}


### PR DESCRIPTION
Currently HttpApi has a declare_stage function that can be used to add extra stages, but it doesn't allow to completely configure new stages with ease, i.e. if you use a domain name and zone. It is also lacking a way to add lambda permissions as it's done elsewhere. Here we introduce a new parameter in the constructor to list and configure all the stages so they are all generated the same way without having to call an extra function later