### PR TITLE
Add a function in AutoVersion to retrieve versions

### DIFF
--- a/src/e3/aws/troposphere/awslambda/__init__.py
+++ b/src/e3/aws/troposphere/awslambda/__init__.py
@@ -650,6 +650,17 @@ class AutoVersion(Construct):
         self.latest.provisioned_concurrency_config = provisioned_concurrency_config
         self.latest.code_sha256 = code_sha256
 
+    def get_version(self, number: int) -> Version | None:
+        """Return a version.
+
+        :param number: version number
+        """
+        return (
+            self.versions[number - 1]
+            if number > 0 and number <= len(self.versions)
+            else None
+        )
+
     @property
     def previous(self) -> Version:
         """Return the previous version.

--- a/tests/tests_e3_aws/troposphere/awslambda/awslambda_test.py
+++ b/tests/tests_e3_aws/troposphere/awslambda/awslambda_test.py
@@ -540,6 +540,8 @@ def test_autoversion_default(stack: Stack, simple_lambda_function: PyFunction) -
     stack.add(auto_version)
     print(stack.export()["Resources"])
     assert stack.export()["Resources"] == EXPECTED_AUTOVERSION_DEFAULT_TEMPLATE
+    assert auto_version.get_version(1).name == "mypylambdaVersion1"
+    assert auto_version.get_version(2).name == "mypylambdaVersion2"
     assert auto_version.previous.name == "mypylambdaVersion1"
     assert auto_version.latest.name == "mypylambdaVersion2"
 


### PR DESCRIPTION
This enables to get a version by its number and avoid doing auto_version.versions[number - 1]