### PR TITLE
Handle str in add_notification_configuration

### DIFF
--- a/tests/tests_e3_aws/troposphere/s3/bucket_notification_string_arns.json
+++ b/tests/tests_e3_aws/troposphere/s3/bucket_notification_string_arns.json
@@ -1,0 +1,98 @@
+{
+    "TestBucket": {
+        "Properties": {
+            "BucketName": "test-bucket",
+            "BucketEncryption": {
+                "ServerSideEncryptionConfiguration": [
+                    {
+                        "ServerSideEncryptionByDefault": {
+                            "SSEAlgorithm": "AES256"
+                        }
+                    }
+                ]
+            },
+            "PublicAccessBlockConfiguration": {
+                "BlockPublicAcls": true,
+                "BlockPublicPolicy": true,
+                "IgnorePublicAcls": true,
+                "RestrictPublicBuckets": true
+            },
+            "VersioningConfiguration": {
+                "Status": "Enabled"
+            },
+            "NotificationConfiguration": {
+                "LambdaConfigurations": [
+                    {
+                        "Event": "s3:ObjectCreated:*",
+                        "Function": "arn:aws:lambda:us-east-2:123456789012:MyFunction"
+                    }
+                ],
+                "TopicConfigurations": [
+                    {
+                        "Event": "s3:ObjectCreated:*",
+                        "Topic": "arn:aws:sns:us-east-2:123456789012:MyTopic"
+                    }
+                ],
+                "QueueConfigurations": [
+                    {
+                        "Event": "s3:ObjectCreated:*",
+                        "Queue": "arn:aws:sqs:us-east-2:123456789012:MyQueue"
+                    }
+                ]
+            }
+        },
+        "Type": "AWS::S3::Bucket"
+    },
+    "TestBucketPolicy": {
+        "Properties": {
+            "Bucket": {
+                "Ref": "TestBucket"
+            },
+            "PolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Deny",
+                        "Principal": {
+                            "AWS": "*"
+                        },
+                        "Action": "s3:*",
+                        "Resource": "arn:aws:s3:::test-bucket/*",
+                        "Condition": {
+                            "Bool": {
+                                "aws:SecureTransport": "false"
+                            }
+                        }
+                    },
+                    {
+                        "Effect": "Deny",
+                        "Principal": {
+                            "AWS": "*"
+                        },
+                        "Action": "s3:PutObject",
+                        "Resource": "arn:aws:s3:::test-bucket/*",
+                        "Condition": {
+                            "StringNotEquals": {
+                                "s3:x-amz-server-side-encryption": "AES256"
+                            }
+                        }
+                    },
+                    {
+                        "Effect": "Deny",
+                        "Principal": {
+                            "AWS": "*"
+                        },
+                        "Action": "s3:PutObject",
+                        "Resource": "arn:aws:s3:::test-bucket/*",
+                        "Condition": {
+                            "Null": {
+                                "s3:x-amz-server-side-encryption": "true"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "Type": "AWS::S3::BucketPolicy"
+    }
+}

--- a/tests/tests_e3_aws/troposphere/s3/s3_test.py
+++ b/tests/tests_e3_aws/troposphere/s3/s3_test.py
@@ -81,3 +81,29 @@ def test_bucket_multi_encryption(stack: Stack) -> None:
         expected_template = json.load(fd)
 
     assert stack.export()["Resources"] == expected_template
+
+
+def test_bucket_notification_string_arns(stack: Stack) -> None:
+    """Test bucket notification with string arns instead of objects."""
+    bucket = Bucket(name="test-bucket")
+    bucket.add_notification_configuration(
+        event="s3:ObjectCreated:*",
+        target="arn:aws:sns:us-east-2:123456789012:MyTopic",
+        permission_suffix="TpUpload",
+    )
+    bucket.add_notification_configuration(
+        event="s3:ObjectCreated:*",
+        target="arn:aws:lambda:us-east-2:123456789012:MyFunction",
+        permission_suffix="TpUpload",
+    )
+    bucket.add_notification_configuration(
+        event="s3:ObjectCreated:*",
+        target="arn:aws:sqs:us-east-2:123456789012:MyQueue",
+        permission_suffix="FileEvent",
+    )
+    stack.add(bucket)
+
+    with open(os.path.join(TEST_DIR, "bucket_notification_string_arns.json")) as fd:
+        expected_template = json.load(fd)
+
+    assert stack.export()["Resources"] == expected_template


### PR DESCRIPTION
The function Bucket.add_notification_configuration can take a str as target but doesn't handle this case. As a str probably implies an external managed resource, we don't create additional policies in this case