### PR TITLE
Fix service name of the VPC endpoint for SES

### DIFF
--- a/src/e3/aws/troposphere/ec2/__init__.py
+++ b/src/e3/aws/troposphere/ec2/__init__.py
@@ -120,7 +120,7 @@ class VPCEndpointsSubnet(Construct):
 
         if interface_endpoints:
             self.interface_endpoints = interface_endpoints
-            if "ses" in [endpoint[0] for endpoint in self.interface_endpoints]:
+            if "email-smtp" in [endpoint[0] for endpoint in self.interface_endpoints]:
                 self.has_ses_endpoint = True
         else:
             self.interface_endpoints = []

--- a/tests/tests_e3_aws/troposphere/ec2/ec2_test.py
+++ b/tests/tests_e3_aws/troposphere/ec2/ec2_test.py
@@ -101,7 +101,7 @@ def test_vpc_with_ses_endpoint(stack: Stack) -> None:
         region="eu-west-1",
         nat_gateway=False,
         interface_endpoints=[
-            ("ses", None),
+            ("email-smtp", None),
         ],
     )
     stack.add(vpc)

--- a/tests/tests_e3_aws/troposphere/ec2/vpc_ses_endpoint.json
+++ b/tests/tests_e3_aws/troposphere/ec2/vpc_ses_endpoint.json
@@ -242,7 +242,7 @@
         },
         "Type": "AWS::EC2::SecurityGroupIngress"
     },
-    "SesEndpoint": {
+    "EmailSmtpEndpoint": {
         "Properties": {
             "PrivateDnsEnabled": true,
             "SecurityGroupIds": [
@@ -250,7 +250,7 @@
                     "Ref": "TestVPCVPCEndpointsSubnetSESSecurityGroup"
                 }
             ],
-            "ServiceName": "com.amazonaws.eu-west-1.ses",
+            "ServiceName": "com.amazonaws.eu-west-1.email-smtp",
             "SubnetIds": [
                 {
                     "Ref": "TestVPCVPCEndpointsSubnetSubnet"


### PR DESCRIPTION
The service name of the SES VPC endpoint is email-smtp and not ses.