### PR TITLE
Use urlencode to create query string

### DIFF
--- a/src/e3/aws/troposphere/awslambda/flask_apigateway_wrapper.py
+++ b/src/e3/aws/troposphere/awslambda/flask_apigateway_wrapper.py
@@ -6,24 +6,10 @@ import json
 import io
 import sys
 import base64
+from urllib.parse import urlencode
 
 if TYPE_CHECKING:
     from typing import Any
-
-
-def get_raw_query_string(mlt_vqsp: dict[str, list]) -> str:
-    """Create the raw query string from the multiValueQueryStringParameters.
-
-    :param mlt_vqsp: the multiValueQueryStringParameters of a REST's API event
-    :return: a raw query string
-    """
-    if mlt_vqsp:
-        rawquerystring = ""
-        for el in mlt_vqsp:
-            rawquerystring += "&".join([f"{el}={v}" for v in mlt_vqsp[el]])
-            rawquerystring += "&"
-        return rawquerystring[:-1]
-    return ""
 
 
 class FlaskLambdaHandler:
@@ -112,7 +98,7 @@ class FlaskLambdaHandler:
             "PATH_INFO": path,
             "QUERY_STRING": event["rawQueryString"]
             if http
-            else get_raw_query_string(event["multiValueQueryStringParameters"]),
+            else urlencode(event["multiValueQueryStringParameters"], doseq=True),
             "REMOTE_ADDR": request_ctx["identity"]["sourceIp"],
             "REQUEST_METHOD": http_method,
             "SCRIPT_NAME": script_name,

--- a/tests/tests_e3_aws/troposphere/awslambda/awslambda_test.py
+++ b/tests/tests_e3_aws/troposphere/awslambda/awslambda_test.py
@@ -22,7 +22,6 @@ from e3.aws.troposphere.awslambda import (
     BlueGreenAliases,
     BlueGreenAliasConfiguration,
 )
-from e3.aws.troposphere.awslambda.flask_apigateway_wrapper import get_raw_query_string
 
 SOURCE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "source_dir")
 
@@ -641,9 +640,3 @@ def test_bluegreenaliases(stack: Stack, simple_lambda_function: PyFunction) -> N
     assert stack.export()["Resources"] == EXPECTED_BLUEGREENALIASES_TEMPLATE
     assert aliases.blue.name == "MypylambdaProdAlias"
     assert aliases.green.name == "MypylambdaBetaAlias"
-
-
-def test_get_raw_query_string():
-    query_parameters = {"po": ["1", "mml"], "test": ["hehe"], "n": [1]}
-    query_string = "po=1&po=mml&test=hehe&n=1"
-    assert get_raw_query_string(query_parameters) == query_string

--- a/tests/tests_e3_aws/troposphere/awslambda/source_dir/event.json
+++ b/tests/tests_e3_aws/troposphere/awslambda/source_dir/event.json
@@ -1,0 +1,112 @@
+{
+    "resource": "/",
+    "path": "/Prod",
+    "httpMethod": "GET",
+    "headers": {
+        "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-US,en;q=0.9",
+        "cookie": "s_fid=7AAB6XMPLAFD9BBF-0643XMPL09956DE2; regStatus=pre-register",
+        "Host": "abcd12345.execute-api.us-east-2.amazonaws.com",
+        "sec-fetch-dest": "document",
+        "sec-fetch-mode": "navigate",
+        "sec-fetch-site": "none",
+        "upgrade-insecure-requests": "1",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
+        "X-Amzn-Trace-Id": "Root=1-5e66d96f-7491f09xmpl79d18acf3d050",
+        "X-Forwarded-For": "1.2.3.4",
+        "X-Forwarded-Port": "443",
+        "X-Forwarded-Proto": "https"
+    },
+    "multiValueHeaders": {
+        "accept": [
+            "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"
+        ],
+        "accept-encoding": [
+            "gzip, deflate, br"
+        ],
+        "accept-language": [
+            "en-US,en;q=0.9"
+        ],
+        "cookie": [
+            "s_fid=7AABXMPL1AFD9BBF-0643XMPL09956DE2; regStatus=pre-register;"
+        ],
+        "Host": [
+            "abcd12345.execute-api.ca-central-1.amazonaws.com"
+        ],
+        "sec-fetch-dest": [
+            "document"
+        ],
+        "sec-fetch-mode": [
+            "navigate"
+        ],
+        "sec-fetch-site": [
+            "none"
+        ],
+        "upgrade-insecure-requests": [
+            "1"
+        ],
+        "User-Agent": [
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36"
+        ],
+        "X-Amzn-Trace-Id": [
+            "Root=1-5e66d96f-7491f09xmpl79d18acf3d050"
+        ],
+        "X-Forwarded-For": [
+            "1.2.3.4"
+        ],
+        "X-Forwarded-Port": [
+            "443"
+        ],
+        "X-Forwarded-Proto": [
+            "https"
+        ]
+    },
+    "queryStringParameters": {
+        "m": "été",
+        "n": "kko"
+    },
+    "multiValueQueryStringParameters": {
+        "m": [
+            "été"
+        ],
+        "n": [
+            "48",
+            "kko"
+        ]
+    },
+    "pathParameters": null,
+    "stageVariables": null,
+    "requestContext": {
+        "resourceId": "2gxmpl",
+        "resourcePath": "/",
+        "httpMethod": "GET",
+        "extendedRequestId": "JJbxmplHYosFVYQ=",
+        "requestTime": "10/Mar/2020:00:03:59 +0000",
+        "path": "/Prod",
+        "accountId": "123456789012",
+        "protocol": "HTTP/1.1",
+        "stage": "Prod",
+        "domainPrefix": "abcd12345",
+        "requestTimeEpoch": 1583798639428,
+        "requestId": "77375676-xmpl-4b79-853a-f982474efe18",
+        "identity": {
+            "cognitoIdentityPoolId": null,
+            "accountId": null,
+            "cognitoIdentityId": null,
+            "caller": null,
+            "sourceIp": "1.2.3.4",
+            "principalOrgId": null,
+            "accessKey": null,
+            "cognitoAuthenticationType": null,
+            "cognitoAuthenticationProvider": null,
+            "userArn": null,
+            "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
+            "user": null
+        },
+        "domainName": "abcd12345.execute-api.us-east-2.amazonaws.com",
+        "apiId": "abcd12345"
+    },
+    "body": "{\n    \"object_kind\": \"push\",\n    \"event_name\": \"push\",\n    \"before\": \"02f17b42dc36589eb7007e34e6d5a84273f5021e\",\n    \"after\": \"424ec9d4b14a8be1391a4824f4f7f54ebf6802ac\",\n    \"ref\": \"refs/heads/tests-webhook/rena\",\n    \"checkout_sha\": \"424ec9d4b14a8be1391a4824f4f7f54ebf6802ac\",\n    \"message\": null,\n    \"user_id\": 30,\n    \"user_name\": \"Romaric Kanyamibwa\",\n    \"user_username\": \"kanya\",\n    \"user_email\": \"\",\n    \"user_avatar\": \"https://secure.gravatar.com/avatar/86600f9a5b506eed2ecb6a0badb1ef4d?s=80&d=identicon\",\n    \"project_id\": 102,\n    \"project\": {\n        \"id\": 102,\n        \"name\": \"Typhon To Gitlab Test Repo\",\n        \"description\": null,\n        \"web_url\": \"https://gitlab.adacore-it.com/kanya/typhon-to-gitlab-test-repo\",\n        \"avatar_url\": null,\n        \"git_ssh_url\": \"git@ssh.gitlab.adacore-it.com:kanya/typhon-to-gitlab-test-repo.git\",\n        \"git_http_url\": \"https://gitlab.adacore-it.com/kanya/typhon-to-gitlab-test-repo.git\",\n        \"namespace\": \"Romaric Kanyamibwa\",\n        \"visibility_level\": 10,\n        \"path_with_namespace\": \"kanya/typhon-to-gitlab-test-repo\",\n        \"default_branch\": \"main\",\n        \"ci_config_path\": \"\",\n        \"homepage\": \"https://gitlab.adacore-it.com/kanya/typhon-to-gitlab-test-repo\",\n        \"url\": \"git@ssh.gitlab.adacore-it.com:kanya/typhon-to-gitlab-test-repo.git\",\n        \"ssh_url\": \"git@ssh.gitlab.adacore-it.com:kanya/typhon-to-gitlab-test-repo.git\",\n        \"http_url\": \"https://gitlab.adacore-it.com/kanya/typhon-to-gitlab-test-repo.git\"\n    },\n    \"commits\": [\n        {\n            \"id\": \"424ec9d4b14a8be1391a4824f4f7f54ebf6802ac\",\n            \"message\": \"Update CHANGELOG\\r\\n\\r\\nref kanya/typhon-to-gitlab-test-repo#6\",\n            \"title\": \"Update CHANGELOG\",\n            \"timestamp\": \"2023-03-15T16:55:33+00:00\",\n            \"url\": \"https://gitlab.adacore-it.com/kanya/typhon-to-gitlab-test-repo/-/commit/424ec9d4b14a8be1391a4824f4f7f54ebf6802ac\",\n            \"author\": {\n                \"name\": \"Romaric Kanyamibwa\",\n                \"email\": \"kanya@adacore.com\"\n            },\n            \"added\": [],\n            \"modified\": [\n                \"CHANGELOG\"\n            ],\n            \"removed\": []\n        }\n    ],\n    \"total_commits_count\": 1,\n    \"push_options\": {},\n    \"repository\": {\n        \"name\": \"Typhon To Gitlab Test Repo\",\n        \"url\": \"git@ssh.gitlab.adacore-it.com:kanya/typhon-to-gitlab-test-repo.git\",\n        \"description\": null,\n        \"homepage\": \"https://gitlab.adacore-it.com/kanya/typhon-to-gitlab-test-repo\",\n        \"git_http_url\": \"https://gitlab.adacore-it.com/kanya/typhon-to-gitlab-test-repo.git\",\n        \"git_ssh_url\": \"git@ssh.gitlab.adacore-it.com:kanya/typhon-to-gitlab-test-repo.git\",\n        \"visibility_level\": 10\n    }\n}",
+    "isBase64Encoded": false
+}

--- a/tests/tests_e3_aws/troposphere/awslambda/source_dir/rest_api_wsgi_flask_environment.json
+++ b/tests/tests_e3_aws/troposphere/awslambda/source_dir/rest_api_wsgi_flask_environment.json
@@ -1,0 +1,32 @@
+{
+    "PATH_INFO": "",
+    "QUERY_STRING": "m=%C3%A9t%C3%A9&n=48&n=kko",
+    "REMOTE_ADDR": "1.2.3.4",
+    "REQUEST_METHOD": "GET",
+    "SCRIPT_NAME": "/Prod",
+    "HTTP_HOST": "abcd12345.execute-api.us-east-2.amazonaws.com",
+    "SERVER_NAME": "abcd12345.execute-api.us-east-2.amazonaws.com",
+    "SERVER_PORT": "443",
+    "SERVER_PROTOCOL": "HTTP/1.1",
+    "wsgi.version": [
+        1,
+        0
+    ],
+    "wsgi.url_scheme": "https",
+    "wsgi.multiprocess": false,
+    "wsgi.multithread": false,
+    "wsgi.run_once": false,
+    "HTTP_ACCEPT": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+    "HTTP_ACCEPT_ENCODING": "gzip, deflate, br",
+    "HTTP_ACCEPT_LANGUAGE": "en-US,en;q=0.9",
+    "HTTP_COOKIE": "s_fid=7AAB6XMPLAFD9BBF-0643XMPL09956DE2; regStatus=pre-register",
+    "HTTP_SEC_FETCH_DEST": "document",
+    "HTTP_SEC_FETCH_MODE": "navigate",
+    "HTTP_SEC_FETCH_SITE": "none",
+    "HTTP_UPGRADE_INSECURE_REQUESTS": "1",
+    "HTTP_USER_AGENT": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
+    "HTTP_X_AMZN_TRACE_ID": "Root=1-5e66d96f-7491f09xmpl79d18acf3d050",
+    "HTTP_X_FORWARDED_FOR": "1.2.3.4",
+    "HTTP_X_FORWARDED_PORT": "443",
+    "HTTP_X_FORWARDED_PROTO": "https"
+}


### PR DESCRIPTION
We use urlencode to create the rawquerystring instead of a simple join to avoid encoding errors in the flask app.