### PR TITLE
Install typing packages before pre-commit check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,4 +52,9 @@ jobs:
       - uses: actions/setup-python@v2
         with:
            python-version: 3.9
+      - name: Install typing packages
+        run: |
+             python -m pip install -U pip
+             python -m pip install types-requests types-python-dateutil \
+                                   types-PyYAML types-setuptools
       - uses: pre-commit/action@v2.0.0


### PR DESCRIPTION
Mypy 1.1.1 is complaining about missing types and the pre-commit check is going to use this version once typing issues are fixed.