### PR TITLE
Bump flake8 black mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo:  https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 6.0.0
     hooks:
     - id: flake8
       additional_dependencies:
@@ -10,11 +10,11 @@ repos:
         - flake8-docstrings
         - flake8-rst-docstrings
   - repo: https://github.com/ambv/black
-    rev: 22.3.0
+    rev: 23.1.0
     hooks:
     - id: black
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.800
+    rev: v1.1.1
     hooks:
     - id: mypy
       files: '\.py$'


### PR DESCRIPTION
it/org/software-supply-chain/issues#2

Bump Black, Flake8, and Mypy to the latest stable
Black: 23.1.0
Flake8: 6.0.0
MyPy: 1.1.1
