### PR TITLE
Move typing packages install to .pre-commit-config.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,9 +52,4 @@ jobs:
       - uses: actions/setup-python@v2
         with:
            python-version: 3.9
-      - name: Install typing packages
-        run: |
-             python -m pip install -U pip
-             python -m pip install types-requests types-python-dateutil \
-                                   types-PyYAML types-setuptools
       - uses: pre-commit/action@v2.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,8 @@ repos:
     - id: mypy
       files: '\.py$'
       exclude: '^tests/.+$'
+      additional_dependencies:
+        - types-requests
+        - types-python-dateutil
+        - types-PyYAML
+        - types-setuptools


### PR DESCRIPTION
That is were they should be as pre-commit installs its own test environments.