### PR TITLE
Support global secondary indexes on dynamodb tables

### DIFF
--- a/src/e3/aws/troposphere/dynamodb/__init__.py
+++ b/src/e3/aws/troposphere/dynamodb/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING
+from enum import Enum
 from troposphere import dynamodb, GetAtt, Ref, Tags
 from troposphere.dynamodb import PointInTimeRecoverySpecification
 
@@ -11,6 +12,72 @@ if TYPE_CHECKING:
     from e3.aws.troposphere import Stack
 
 
+class ProjectionType(Enum):
+    """Allowed projection types for dynamodb secondary indexes.
+
+    - KEYS_ONLY - projection type chosen when only the index and
+        primary keys are to be projected into the index.
+    - INCLUDE - projection type chosen when in addition to the
+        attributes described in KEYS_ONLY, the secondary index
+        includes other non-key attributes that you specify.
+    - ALL - projection type chosen when all of the table attributes
+        are projected into the index
+    """
+
+    KEYS_ONLY = "KEYS_ONLY"
+    INCLUDE = "INCLUDE"
+    ALL = "ALL"
+
+    def __str__(self):
+        return str(self.value)
+
+
+KEYS_ONLY_PROJECTION = ProjectionType.KEYS_ONLY
+INCLUDE_PROJECTION = ProjectionType.INCLUDE
+ALL_PROJECTION = ProjectionType.ALL
+
+
+class GlobalSecondaryIndex(object):
+    """Global Secondary Index e3-aws abstraction class."""
+
+    def __init__(
+        self,
+        index_name: str,
+        key_schema: dict,
+        projection_type: ProjectionType,
+        non_key_attributes: list[str] | None = None,
+        read_capacity_units: int | None = None,
+        write_capacity_units: int | None = None,
+    ):
+        """Initialize a Global Secondary index.
+
+        :param index_name: name of the global secondary index
+        :param key_schema: specifies the attributes of the key
+            schema for a global secondary index,
+        :param projection_type: type of projection on the global
+            secondary index
+        :param non_key_attributes: the non key attributes that will be
+            projected, defaults to None
+        :param read_capacity_units: the maximum number of strongly
+        consistent reads consumed per second before DynamoDB returns a
+            ThrottlingException (default 10)
+        :param write_capacity_units: the maximum number of writes
+            consumed per second before DynamoDB returns a
+            ThrottlingException (default 10)
+        """
+        self.index_name = index_name
+        self.key_schema = key_schema
+        self.projection_type = projection_type
+        self.non_key_attributes = non_key_attributes
+        if self.projection_type is INCLUDE_PROJECTION:
+            assert (
+                self.non_key_attributes is not None
+            ), "non key attributes parameter is required when the projection "
+            "type is INCLUDE"
+        self.read_capacity_units = read_capacity_units
+        self.write_capacity_units = write_capacity_units
+
+
 class Table(Construct):
     """A DynamoDB Table."""
 
@@ -19,6 +86,7 @@ class Table(Construct):
         name: str,
         attribute_definitions: dict[str, str],
         key_schema: dict[str, str],
+        global_secondary_indexes: list[GlobalSecondaryIndex] | None = None,
         tags: dict[str, str] | None = None,
         point_in_time_recovery_enabled: bool | None = True,
         billing_mode: str | None = None,
@@ -36,6 +104,8 @@ class Table(Construct):
             attributes names and values are DynamoDB attributes types
         :param key_schema: specifies the attributes that make up the primary key for
             the table
+        : param global_secondary_indexes: a list of the Global secondary indexes to
+            be created on the table. Up to 20 global secondary indexes can be created.
         :param tags: dictionary of tags to apply to this resource
         :param point_in_time_recovery_enabled: indicates whether point in time
             recovery is enabled (true) or disabled (false) on the table (default True)
@@ -59,6 +129,7 @@ class Table(Construct):
         self.name = name
         self.attribute_definitions = attribute_definitions
         self.key_schema = key_schema
+        self.global_secondary_indexes = global_secondary_indexes
         self.tags = tags
         self.point_in_time_recovery_enabled = point_in_time_recovery_enabled
         self.billing_mode = billing_mode
@@ -85,7 +156,7 @@ class Table(Construct):
 
     def resources(self, stack: Stack) -> list[AWSObject]:
         """Return list of AWSObject associated with the construct."""
-        params = {
+        params: dict = {
             "TableName": self.name,
             "AttributeDefinitions": [
                 dynamodb.AttributeDefinition(AttributeName=k, AttributeType=v)
@@ -96,6 +167,32 @@ class Table(Construct):
                 for k, v in self.key_schema.items()
             ],
         }
+
+        if self.global_secondary_indexes:
+            params["GlobalSecondaryIndexes"] = []
+            for gsi in self.global_secondary_indexes:
+                projection_param: dict = {"ProjectionType": str(gsi.projection_type)}
+                if gsi.projection_type is INCLUDE_PROJECTION:
+                    projection_param["NonKeyAttributes"] = gsi.non_key_attributes
+
+                params["GlobalSecondaryIndexes"].append(
+                    dynamodb.GlobalSecondaryIndex(
+                        IndexName=gsi.index_name,
+                        KeySchema=[
+                            dynamodb.KeySchema(AttributeName=k, KeyType=v)
+                            for k, v in gsi.key_schema.items()
+                        ],
+                        Projection=dynamodb.Projection(**projection_param),
+                        ProvisionedThroughput=dynamodb.ProvisionedThroughput(
+                            ReadCapacityUnits=gsi.read_capacity_units
+                            if gsi.read_capacity_units is not None
+                            else 10,
+                            WriteCapacityUnits=gsi.write_capacity_units
+                            if self.write_capacity_units is not None
+                            else 10,
+                        ),
+                    )
+                )
 
         if self.tags is not None:
             params["Tags"] = Tags(**self.tags)

--- a/tests/tests_e3_aws/troposphere/dynamodb/dynamodb_table_with_gsi.json
+++ b/tests/tests_e3_aws/troposphere/dynamodb/dynamodb_table_with_gsi.json
@@ -1,0 +1,84 @@
+{
+    "Mytable": {
+        "Properties": {
+            "TableName": "mytable",
+            "AttributeDefinitions": [
+                {
+                    "AttributeName": "id",
+                    "AttributeType": "N"
+                },
+                {
+                    "AttributeName": "prop1",
+                    "AttributeType": "S"
+                },
+                {
+                    "AttributeName": "prop2",
+                    "AttributeType": "S"
+                },
+                {
+                    "AttributeName": "prop3",
+                    "AttributeType": "S"
+                }
+            ],
+            "KeySchema": [
+                {
+                    "AttributeName": "id",
+                    "KeyType": "HASH"
+                },
+                {
+                    "AttributeName": "prop1",
+                    "KeyType": "RANGE"
+                }
+            ],
+            "GlobalSecondaryIndexes": [
+                {
+                    "IndexName": "prop1_index",
+                    "KeySchema": [
+                        {
+                            "AttributeName": "prop1",
+                            "KeyType": "HASH"
+                        },
+                        {
+                            "AttributeName": "id",
+                            "KeyType": "RANGE"
+                        }
+                    ],
+                    "Projection": {
+                        "ProjectionType": "ALL"
+                    },
+                    "ProvisionedThroughput": {
+                        "ReadCapacityUnits": 10,
+                        "WriteCapacityUnits": 10
+                    }
+                },
+                {
+                    "IndexName": "prop2_index",
+                    "KeySchema": [
+                        {
+                            "AttributeName": "prop2",
+                            "KeyType": "HASH"
+                        }
+                    ],
+                    "Projection": {
+                        "ProjectionType": "INCLUDE",
+                        "NonKeyAttributes": [
+                            "prop3"
+                        ]
+                    },
+                    "ProvisionedThroughput": {
+                        "ReadCapacityUnits": 10,
+                        "WriteCapacityUnits": 10
+                    }
+                }
+            ],
+            "PointInTimeRecoverySpecification": {
+                "PointInTimeRecoveryEnabled": true
+            },
+            "ProvisionedThroughput": {
+                "ReadCapacityUnits": 10,
+                "WriteCapacityUnits": 10
+            }
+        },
+        "Type": "AWS::DynamoDB::Table"
+    }
+}


### PR DESCRIPTION
Add support for global secondary indexes on the dynamodb construct. Having secondary indexes will help improve data access on the table.