### PR TITLE
Make flask_apigateway_wrapper handle binary responses

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,13 +8,7 @@ with open(version_file) as f:
 
 
 extras_require = {
-    "test": [
-        "awscli",
-        "pytest",
-        "mock",
-        "requests_mock",
-        "httpretty",
-    ],
+    "test": ["awscli", "pytest", "mock", "requests_mock", "httpretty", "flask"],
 }
 
 setup(

--- a/src/e3/aws/troposphere/awslambda/flask_apigateway_wrapper.py
+++ b/src/e3/aws/troposphere/awslambda/flask_apigateway_wrapper.py
@@ -1,7 +1,7 @@
 # The following package is packaged automatically with Flask lambda.
 # Do not introduce dependencies outside Python standard library.
 from __future__ import annotations
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 import json
 import io
 import sys
@@ -9,7 +9,12 @@ import base64
 from urllib.parse import urlencode
 
 if TYPE_CHECKING:
-    from typing import Any
+    from typing import Any, TypedDict
+
+    class FlaskLambdaResponse(TypedDict):
+        statusCode: int
+        headers: dict[str, Any]
+        body: Any
 
 
 class FlaskLambdaHandler:
@@ -32,7 +37,7 @@ class FlaskLambdaHandler:
         self.status = int(status[:3])
         self.response_headers = dict(response_headers)
 
-    def lambda_handler(self, event, context):
+    def lambda_handler(self, event: dict, context: dict) -> FlaskLambdaResponse:
         """Lambda entry point."""
         self.status = None
         self.response_headers = None
@@ -43,8 +48,8 @@ class FlaskLambdaHandler:
             )
         )
         return {
-            "statusCode": self.status,
-            "headers": self.response_headers,
+            "statusCode": cast(int, self.status),
+            "headers": cast(dict, self.response_headers),
             "body": body,
         }
 

--- a/tests/tests_e3_aws/troposphere/awslambda/source_dir/event-http-base64-response.json
+++ b/tests/tests_e3_aws/troposphere/awslambda/source_dir/event-http-base64-response.json
@@ -1,0 +1,46 @@
+{
+    "version": "2.0",
+    "routeKey": "ANY /base64-response",
+    "rawPath": "/base64-response",
+    "rawQueryString": "",
+    "cookies": [
+        "s_fid=7AABXMPL1AFD9BBF-0643XMPL09956DE2",
+        "regStatus=pre-register"
+    ],
+    "headers": {
+        "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-US,en;q=0.9",
+        "content-length": "0",
+        "host": "abcd12345.execute-api.us-east-2.amazonaws.com",
+        "sec-fetch-dest": "document",
+        "sec-fetch-mode": "navigate",
+        "sec-fetch-site": "cross-site",
+        "sec-fetch-user": "?1",
+        "upgrade-insecure-requests": "1",
+        "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
+        "x-amzn-trace-id": "Root=1-5e6722a7-cc56xmpl46db7ae02d4da47e",
+        "x-forwarded-for": "1.2.3.4",
+        "x-forwarded-port": "443",
+        "x-forwarded-proto": "https"
+    },
+    "requestContext": {
+        "accountId": "123456789012",
+        "apiId": "abcd12345",
+        "domainName": "abcd12345.execute-api.us-east-2.amazonaws.com",
+        "domainPrefix": "abcd12345",
+        "http": {
+            "method": "GET",
+            "path": "/base64-response",
+            "protocol": "HTTP/1.1",
+            "sourceIp": "1.2.3.4",
+            "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36"
+        },
+        "requestId": "JKJaXmPLvHcESHA=",
+        "routeKey": "ANY /base64-response",
+        "stage": "default",
+        "time": "10/Mar/2020:05:16:23 +0000",
+        "timeEpoch": 1583817383220
+    },
+    "isBase64Encoded": true
+}

--- a/tests/tests_e3_aws/troposphere/awslambda/source_dir/event-http-text-response.json
+++ b/tests/tests_e3_aws/troposphere/awslambda/source_dir/event-http-text-response.json
@@ -1,0 +1,46 @@
+{
+    "version": "2.0",
+    "routeKey": "ANY /text-response",
+    "rawPath": "/text-response",
+    "rawQueryString": "",
+    "cookies": [
+        "s_fid=7AABXMPL1AFD9BBF-0643XMPL09956DE2",
+        "regStatus=pre-register"
+    ],
+    "headers": {
+        "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-US,en;q=0.9",
+        "content-length": "0",
+        "host": "abcd12345.execute-api.us-east-2.amazonaws.com",
+        "sec-fetch-dest": "document",
+        "sec-fetch-mode": "navigate",
+        "sec-fetch-site": "cross-site",
+        "sec-fetch-user": "?1",
+        "upgrade-insecure-requests": "1",
+        "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
+        "x-amzn-trace-id": "Root=1-5e6722a7-cc56xmpl46db7ae02d4da47e",
+        "x-forwarded-for": "1.2.3.4",
+        "x-forwarded-port": "443",
+        "x-forwarded-proto": "https"
+    },
+    "requestContext": {
+        "accountId": "123456789012",
+        "apiId": "abcd12345",
+        "domainName": "abcd12345.execute-api.us-east-2.amazonaws.com",
+        "domainPrefix": "abcd12345",
+        "http": {
+            "method": "GET",
+            "path": "/text-response",
+            "protocol": "HTTP/1.1",
+            "sourceIp": "1.2.3.4",
+            "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36"
+        },
+        "requestId": "JKJaXmPLvHcESHA=",
+        "routeKey": "ANY /text-response",
+        "stage": "default",
+        "time": "10/Mar/2020:05:16:23 +0000",
+        "timeEpoch": 1583817383220
+    },
+    "isBase64Encoded": true
+}


### PR DESCRIPTION
From many examples, "When dealing with binary data, the ;isBase64Encoded property in the output of the Lambda function must be set to true. The body property must also contain the base64 encoded binary media".

However flask_apigateway_wrapper doesn't currently allow to change isBase64Encoded when returning a binary response.

The following change is inspired by https://github.com/logandk/serverless-wsgi/blob/master/serverless_wsgi.py#L151 