### PR TITLE
Rename add_jwt_authorizer for RestApi

### DIFF
--- a/src/e3/aws/troposphere/apigateway/__init__.py
+++ b/src/e3/aws/troposphere/apigateway/__init__.py
@@ -249,16 +249,6 @@ class Api(Construct):
         """
         return Ref(self.stage_logical_id(stage_name))
 
-    @abstractmethod
-    def add_jwt_authorizer(self, name: str, header: str = "Authorization") -> None:
-        """Declare a JWT authorizer.
-
-        :param name: authorizer name
-        :param header: the request header holding the authorization token
-            submitted by the client
-        """
-        pass
-
     def cfn_policy_document(self, stack: Stack) -> PolicyDocument:
         """Get policy needed by CloudFormation."""
         return PolicyDocument(
@@ -443,7 +433,7 @@ class HttpApi(Api):
             integration_uri if integration_uri is not None else lambda_arn
         )
 
-    def add_jwt_authorizer(  # type: ignore
+    def add_jwt_authorizer(
         self, name: str, audience: list[str], issuer: str, header: str = "Authorization"
     ) -> None:
         """Declare a JWT authorizer.
@@ -762,7 +752,7 @@ class RestApi(Api):
         self.iam_path = iam_path
         self.policy = policy
 
-    def add_jwt_authorizer(  # type: ignore
+    def add_cognito_authorizer(
         # we ignore the incompatible signature mypy errors
         self,
         name: str,

--- a/tests/tests_e3_aws/troposphere/apigateway/apigateway_test.py
+++ b/tests/tests_e3_aws/troposphere/apigateway/apigateway_test.py
@@ -632,7 +632,7 @@ def test_rest_api_custom_domain(stack: Stack, lambda_fun: PyFunction) -> None:
             ),
         ],
     )
-    rest_api.add_jwt_authorizer(
+    rest_api.add_cognito_authorizer(
         name="testauthorizer",
         providers_arn=[
             "arn:aws:cognito-idp:eu-west-1:123456789012:userpool/eu-west-1_abc123"
@@ -689,7 +689,7 @@ def test_rest_api_custom_domain_stages(stack: Stack, lambda_fun: PyFunction) -> 
             ),
         ],
     )
-    rest_api.add_jwt_authorizer(
+    rest_api.add_cognito_authorizer(
         name="testauthorizer",
         providers_arn=[
             "arn:aws:cognito-idp:eu-west-1:123456789012:userpool/eu-west-1_abc123"


### PR DESCRIPTION
There is no JWT authorizer for a REST API