### PR TITLE
Remove AuthorizerUri in add_cognito_authorizer

### DIFF
--- a/src/e3/aws/troposphere/apigateway/__init__.py
+++ b/src/e3/aws/troposphere/apigateway/__init__.py
@@ -769,7 +769,6 @@ class RestApi(Api):
             submitted by the client
         """
         self.authorizers[name] = {
-            "AuthorizerUri": self.integration_uri,
             "IdentitySource": f"method.request.header.{header}",
             "Name": name,
             "ProviderARNs": providers_arn,

--- a/tests/tests_e3_aws/troposphere/apigateway/apigatewayv1_test_custom_domain.json
+++ b/tests/tests_e3_aws/troposphere/apigateway/apigatewayv1_test_custom_domain.json
@@ -227,16 +227,6 @@
     },
     "Testauthorizer": {
         "Properties": {
-            "AuthorizerUri": {
-                "Fn::Sub": [
-                    "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${lambdaArn}/invocations",
-                    {
-                        "lambdaArn": {
-                            "Ref": "Mypylambda"
-                        }
-                    }
-                ]
-            },
             "IdentitySource": "method.request.header.Authorization",
             "Name": "testauthorizer",
             "ProviderARNs": [

--- a/tests/tests_e3_aws/troposphere/apigateway/apigatewayv1_test_custom_domain_stages.json
+++ b/tests/tests_e3_aws/troposphere/apigateway/apigatewayv1_test_custom_domain_stages.json
@@ -309,16 +309,6 @@
     },
     "Testauthorizer": {
         "Properties": {
-            "AuthorizerUri": {
-                "Fn::Sub": [
-                    "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${lambdaArn}/invocations",
-                    {
-                        "lambdaArn": {
-                            "Ref": "Mypylambda"
-                        }
-                    }
-                ]
-            },
             "IdentitySource": "method.request.header.Authorization",
             "Name": "testauthorizer",
             "ProviderARNs": [


### PR DESCRIPTION
The parameter AuthorizerUri is meant for TOKEN or REQUEST authorizers