### PR TITLE
Add a bucket_exists option to BucketWithRoles

### DIFF
--- a/src/e3/aws/troposphere/s3/__init__.py
+++ b/src/e3/aws/troposphere/s3/__init__.py
@@ -25,6 +25,7 @@ class BucketWithRoles(Construct):
         trusted_accounts: list[str],
         iam_read_root_name: str = "Read",
         iam_write_root_name: str = "Write",
+        bucket_exists: bool | None = None,
         **bucket_kwargs: Any,
     ) -> None:
         """Initialize BucketWithRoles instance.
@@ -35,11 +36,13 @@ class BucketWithRoles(Construct):
         :param trusted_accounts: accounts to be trusted by access roles
         :param iam_read_root_name: root name for read access roles and policy
         :param iam_write_root_name: root name for write access roles and policy
+        :param bucket_exists: if True then the bucket is not created
         :param bucket_kwargs: keyword arguments to pass to the bucket constructor
         """
         self.name = name
         self.iam_names_prefix = iam_names_prefix
         self.trusted_accounts = trusted_accounts
+        self.bucket_exists = bucket_exists
 
         self.bucket = Bucket(name=self.name, **bucket_kwargs)
         self.read_policy = ManagedPolicy(
@@ -93,8 +96,7 @@ class BucketWithRoles(Construct):
 
     def resources(self, stack: Stack) -> list[AWSObject | Construct]:
         """Return resources associated with the construct."""
-        return [
-            self.bucket,
+        return ([] if self.bucket_exists else [self.bucket]) + [
             self.read_policy,
             self.read_role,
             self.push_policy,

--- a/tests/tests_e3_aws/troposphere/s3/bucket-with-roles-exists.json
+++ b/tests/tests_e3_aws/troposphere/s3/bucket-with-roles-exists.json
@@ -1,0 +1,119 @@
+{
+    "TestBucketRestorePolicy": {
+        "Properties": {
+            "Description": "Grants read access permissions to test-bucket-with-roles bucket",
+            "ManagedPolicyName": "TestBucketRestorePolicy",
+            "PolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": [
+                            "s3:GetObject"
+                        ],
+                        "Resource": "arn:aws:s3:::test-bucket-with-roles/*"
+                    },
+                    {
+                        "Effect": "Allow",
+                        "Action": [
+                            "s3:ListBucket"
+                        ],
+                        "Resource": "arn:aws:s3:::test-bucket-with-roles"
+                    }
+                ]
+            },
+            "Path": "/test/"
+        },
+        "Type": "AWS::IAM::ManagedPolicy"
+    },
+    "TestBucketRestoreRole": {
+        "Properties": {
+            "RoleName": "TestBucketRestoreRole",
+            "Description": "Role with read access to test-bucket-with-roles bucket.",
+            "ManagedPolicyArns": [
+                {
+                    "Ref": "TestBucketRestorePolicy"
+                }
+            ],
+            "AssumeRolePolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": "sts:AssumeRole",
+                        "Principal": {
+                            "AWS": [
+                                "arn:aws:iam::123456789:root"
+                            ]
+                        }
+                    }
+                ]
+            },
+            "Tags": [
+                {
+                    "Key": "Name",
+                    "Value": "TestBucketRestoreRole"
+                }
+            ],
+            "Path": "/test/"
+        },
+        "Type": "AWS::IAM::Role"
+    },
+    "TestBucketPushPolicy": {
+        "Properties": {
+            "Description": "Grants write access permissions to test-bucket-with-roles bucket",
+            "ManagedPolicyName": "TestBucketPushPolicy",
+            "PolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": [
+                            "s3:PutObject",
+                            "s3:DeleteObject"
+                        ],
+                        "Resource": "arn:aws:s3:::test-bucket-with-roles/*"
+                    }
+                ]
+            },
+            "Path": "/test/"
+        },
+        "Type": "AWS::IAM::ManagedPolicy"
+    },
+    "TestBucketPushRole": {
+        "Properties": {
+            "RoleName": "TestBucketPushRole",
+            "Description": "Role with read and write access to test-bucket-with-roles bucket.",
+            "ManagedPolicyArns": [
+                {
+                    "Ref": "TestBucketPushPolicy"
+                },
+                {
+                    "Ref": "TestBucketRestorePolicy"
+                }
+            ],
+            "AssumeRolePolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": "sts:AssumeRole",
+                        "Principal": {
+                            "AWS": [
+                                "arn:aws:iam::123456789:root"
+                            ]
+                        }
+                    }
+                ]
+            },
+            "Tags": [
+                {
+                    "Key": "Name",
+                    "Value": "TestBucketPushRole"
+                }
+            ],
+            "Path": "/test/"
+        },
+        "Type": "AWS::IAM::Role"
+    }
+}

--- a/tests/tests_e3_aws/troposphere/s3/s3_test.py
+++ b/tests/tests_e3_aws/troposphere/s3/s3_test.py
@@ -68,6 +68,25 @@ def test_bucket_with_roles(stack: Stack) -> None:
     assert stack.export()["Resources"] == expected_template
 
 
+def test_bucket_with_roles_exists(stack: Stack) -> None:
+    """Test BucketWithRoles when the bucket already exists."""
+    bucket = BucketWithRoles(
+        name="test-bucket-with-roles",
+        iam_names_prefix="TestBucket",
+        iam_read_root_name="Restore",
+        iam_write_root_name="Push",
+        iam_path="/test/",
+        trusted_accounts=["123456789"],
+        bucket_exists=True,
+    )
+    stack.add(bucket)
+
+    with open(os.path.join(TEST_DIR, "bucket-with-roles-exists.json")) as fd:
+        expected_template = json.load(fd)
+
+    assert stack.export()["Resources"] == expected_template
+
+
 def test_bucket_multi_encryption(stack: Stack) -> None:
     """Test bucket accepting multiple types of encryptions and without default."""
     bucket = Bucket(


### PR DESCRIPTION
It can be useful to use BucketWithRoles without creating the bucket, in case you want to add RW roles to an existing bucket