### PR TITLE
Download Python packages according to lambda runtime

### DIFF
--- a/src/e3/aws/troposphere/awslambda/__init__.py
+++ b/src/e3/aws/troposphere/awslambda/__init__.py
@@ -412,12 +412,14 @@ class PyFunction(Function):
 
         # Install the requirements
         if self.requirement_file is not None:
+            assert self.runtime is not None
             p = Run(
                 [
                     sys.executable,
                     "-m",
                     "pip",
                     "install",
+                    f"--python-version={self.runtime.lstrip('python')}",
                     f"--target={package_dir}",
                     "-r",
                     self.requirement_file,

--- a/tests/tests_e3_aws/troposphere/awslambda/awslambda_test.py
+++ b/tests/tests_e3_aws/troposphere/awslambda/awslambda_test.py
@@ -6,6 +6,8 @@ import os
 import pytest
 import json
 import io
+from unittest.mock import patch
+import sys
 
 from flask import Flask, send_file
 from troposphere.awslambda import (
@@ -393,6 +395,39 @@ def test_pyfunction(stack: Stack) -> None:
     )
     print(stack.export()["Resources"])
     assert stack.export()["Resources"] == EXPECTED_PYFUNCTION_TEMPLATE
+
+
+def test_pyfunction_with_requirements(tmp_path, stack: Stack) -> None:
+    """Test PyFunction creation."""
+    stack.s3_bucket = "cfn_bucket"
+    stack.s3_key = "templates/"
+    code_dir = tmp_path
+
+    with patch("e3.aws.troposphere.awslambda.Run") as mock_run:
+        mock_run.return_value.status = 0
+        PyFunction(
+            name="mypylambda",
+            description="this is a test",
+            role="somearn",
+            runtime="python3.9",
+            code_dir=str(code_dir),
+            handler="app.main",
+            requirement_file="requirements.txt",
+        ).create_data_dir("dummy")
+    # Ensure the right pip command is called
+    mock_run.assert_called_once_with(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--python-version=3.9",
+            "--target=dummy/Mypylambda/package",
+            "-r",
+            "requirements.txt",
+        ],
+        output=None,
+    )
 
 
 def test_pyfunction_policy_document(stack: Stack) -> None:


### PR DESCRIPTION
Packages should be downloaded for the Python version of the Lambda's runtime requested and not according to the version of the Python interpreter running e3-aws.