### PR TITLE
Fix VPC endpoint IDs

### DIFF
--- a/src/e3/aws/troposphere/ec2/__init__.py
+++ b/src/e3/aws/troposphere/ec2/__init__.py
@@ -222,7 +222,7 @@ class VPCEndpointsSubnet(Construct):
 
             endpoints.append(
                 ec2.VPCEndpoint(
-                    name_to_id(f"{service_name}Endpoint"),
+                    name_to_id(f"{self.vpc.name}-{service_name}Endpoint"),
                     PrivateDnsEnabled="true",
                     SecurityGroupIds=[security_group_id],
                     ServiceName=f"com.amazonaws.{self.region}.{service_name}",

--- a/tests/tests_e3_aws/troposphere/ec2/vpc.json
+++ b/tests/tests_e3_aws/troposphere/ec2/vpc.json
@@ -242,7 +242,7 @@
         },
         "Type": "AWS::EC2::SecurityGroupIngress"
     },
-    "LogsEndpoint": {
+    "TestVPCLogsEndpoint": {
         "Properties": {
             "PrivateDnsEnabled": true,
             "SecurityGroupIds": [
@@ -278,7 +278,7 @@
         },
         "Type": "AWS::EC2::VPCEndpoint"
     },
-    "EcrapiEndpoint": {
+    "TestVPCEcrapiEndpoint": {
         "Properties": {
             "PrivateDnsEnabled": true,
             "SecurityGroupIds": [
@@ -314,7 +314,7 @@
         },
         "Type": "AWS::EC2::VPCEndpoint"
     },
-    "EcrdkrEndpoint": {
+    "TestVPCEcrdkrEndpoint": {
         "Properties": {
             "PrivateDnsEnabled": true,
             "SecurityGroupIds": [
@@ -350,7 +350,7 @@
         },
         "Type": "AWS::EC2::VPCEndpoint"
     },
-    "StsEndpoint": {
+    "TestVPCStsEndpoint": {
         "Properties": {
             "PrivateDnsEnabled": true,
             "SecurityGroupIds": [
@@ -371,7 +371,7 @@
         },
         "Type": "AWS::EC2::VPCEndpoint"
     },
-    "SecretsmanagerEndpoint": {
+    "TestVPCSecretsmanagerEndpoint": {
         "Properties": {
             "PrivateDnsEnabled": true,
             "SecurityGroupIds": [

--- a/tests/tests_e3_aws/troposphere/ec2/vpc_ses_and_other_endpoints.json
+++ b/tests/tests_e3_aws/troposphere/ec2/vpc_ses_and_other_endpoints.json
@@ -242,7 +242,7 @@
         },
         "Type": "AWS::EC2::SecurityGroupIngress"
     },
-    "EmailSmtpEndpoint": {
+    "TestVPCEmailSmtpEndpoint": {
         "Properties": {
             "PrivateDnsEnabled": true,
             "SecurityGroupIds": [
@@ -263,7 +263,7 @@
         },
         "Type": "AWS::EC2::VPCEndpoint"
     },
-    "LogsEndpoint": {
+    "TestVPCLogsEndpoint": {
         "Properties": {
             "PrivateDnsEnabled": true,
             "SecurityGroupIds": [
@@ -284,7 +284,7 @@
         },
         "Type": "AWS::EC2::VPCEndpoint"
     },
-    "StsEndpoint": {
+    "TestVPCStsEndpoint": {
         "Properties": {
             "PrivateDnsEnabled": true,
             "SecurityGroupIds": [

--- a/tests/tests_e3_aws/troposphere/ec2/vpc_ses_endpoint.json
+++ b/tests/tests_e3_aws/troposphere/ec2/vpc_ses_endpoint.json
@@ -242,7 +242,7 @@
         },
         "Type": "AWS::EC2::SecurityGroupIngress"
     },
-    "EmailSmtpEndpoint": {
+    "TestVPCEmailSmtpEndpoint": {
         "Properties": {
             "PrivateDnsEnabled": true,
             "SecurityGroupIds": [


### PR DESCRIPTION
Their IDs must be prefixed by the name of the VPC to make it possible to deploy multiple VPCs with endpoints for the same services in the same stack.