### PR TITLE
Add read/write_trusted_accounts parameters

### DIFF
--- a/tests/tests_e3_aws/troposphere/s3/bucket-with-roles-trusted-accounts.json
+++ b/tests/tests_e3_aws/troposphere/s3/bucket-with-roles-trusted-accounts.json
@@ -1,0 +1,195 @@
+{
+    "TestBucketWithRoles": {
+        "Properties": {
+            "BucketName": "test-bucket-with-roles",
+            "BucketEncryption": {
+                "ServerSideEncryptionConfiguration": [
+                    {
+                        "ServerSideEncryptionByDefault": {
+                            "SSEAlgorithm": "AES256"
+                        }
+                    }
+                ]
+            },
+            "PublicAccessBlockConfiguration": {
+                "BlockPublicAcls": true,
+                "BlockPublicPolicy": true,
+                "IgnorePublicAcls": true,
+                "RestrictPublicBuckets": true
+            },
+            "VersioningConfiguration": {
+                "Status": "Enabled"
+            }
+        },
+        "Type": "AWS::S3::Bucket"
+    },
+    "TestBucketWithRolesPolicy": {
+        "Properties": {
+            "Bucket": {
+                "Ref": "TestBucketWithRoles"
+            },
+            "PolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Deny",
+                        "Principal": {
+                            "AWS": "*"
+                        },
+                        "Action": "s3:*",
+                        "Resource": "arn:aws:s3:::test-bucket-with-roles/*",
+                        "Condition": {
+                            "Bool": {
+                                "aws:SecureTransport": "false"
+                            }
+                        }
+                    },
+                    {
+                        "Effect": "Deny",
+                        "Principal": {
+                            "AWS": "*"
+                        },
+                        "Action": "s3:PutObject",
+                        "Resource": "arn:aws:s3:::test-bucket-with-roles/*",
+                        "Condition": {
+                            "StringNotEquals": {
+                                "s3:x-amz-server-side-encryption": "AES256"
+                            }
+                        }
+                    },
+                    {
+                        "Effect": "Deny",
+                        "Principal": {
+                            "AWS": "*"
+                        },
+                        "Action": "s3:PutObject",
+                        "Resource": "arn:aws:s3:::test-bucket-with-roles/*",
+                        "Condition": {
+                            "Null": {
+                                "s3:x-amz-server-side-encryption": "true"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "Type": "AWS::S3::BucketPolicy"
+    },
+    "TestBucketRestorePolicy": {
+        "Properties": {
+            "Description": "Grants read access permissions to test-bucket-with-roles bucket",
+            "ManagedPolicyName": "TestBucketRestorePolicy",
+            "PolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": [
+                            "s3:GetObject"
+                        ],
+                        "Resource": "arn:aws:s3:::test-bucket-with-roles/*"
+                    },
+                    {
+                        "Effect": "Allow",
+                        "Action": [
+                            "s3:ListBucket"
+                        ],
+                        "Resource": "arn:aws:s3:::test-bucket-with-roles"
+                    }
+                ]
+            },
+            "Path": "/test/"
+        },
+        "Type": "AWS::IAM::ManagedPolicy"
+    },
+    "TestBucketRestoreRole": {
+        "Properties": {
+            "RoleName": "TestBucketRestoreRole",
+            "Description": "Role with read access to test-bucket-with-roles bucket.",
+            "ManagedPolicyArns": [
+                {
+                    "Ref": "TestBucketRestorePolicy"
+                }
+            ],
+            "AssumeRolePolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": "sts:AssumeRole",
+                        "Principal": {
+                            "AWS": [
+                                "arn:aws:iam::123456789:root"
+                            ]
+                        }
+                    }
+                ]
+            },
+            "Tags": [
+                {
+                    "Key": "Name",
+                    "Value": "TestBucketRestoreRole"
+                }
+            ],
+            "Path": "/test/"
+        },
+        "Type": "AWS::IAM::Role"
+    },
+    "TestBucketPushPolicy": {
+        "Properties": {
+            "Description": "Grants write access permissions to test-bucket-with-roles bucket",
+            "ManagedPolicyName": "TestBucketPushPolicy",
+            "PolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": [
+                            "s3:PutObject",
+                            "s3:DeleteObject"
+                        ],
+                        "Resource": "arn:aws:s3:::test-bucket-with-roles/*"
+                    }
+                ]
+            },
+            "Path": "/test/"
+        },
+        "Type": "AWS::IAM::ManagedPolicy"
+    },
+    "TestBucketPushRole": {
+        "Properties": {
+            "RoleName": "TestBucketPushRole",
+            "Description": "Role with read and write access to test-bucket-with-roles bucket.",
+            "ManagedPolicyArns": [
+                {
+                    "Ref": "TestBucketPushPolicy"
+                },
+                {
+                    "Ref": "TestBucketRestorePolicy"
+                }
+            ],
+            "AssumeRolePolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": "sts:AssumeRole",
+                        "Principal": {
+                            "AWS": [
+                                "arn:aws:iam::987654321:root"
+                            ]
+                        }
+                    }
+                ]
+            },
+            "Tags": [
+                {
+                    "Key": "Name",
+                    "Value": "TestBucketPushRole"
+                }
+            ],
+            "Path": "/test/"
+        },
+        "Type": "AWS::IAM::Role"
+    }
+}

--- a/tests/tests_e3_aws/troposphere/s3/s3_test.py
+++ b/tests/tests_e3_aws/troposphere/s3/s3_test.py
@@ -87,6 +87,25 @@ def test_bucket_with_roles_exists(stack: Stack) -> None:
     assert stack.export()["Resources"] == expected_template
 
 
+def test_bucket_with_roles_trusted_accounts(stack: Stack) -> None:
+    """Test BucketWithRoles with additional trusted accounts."""
+    bucket = BucketWithRoles(
+        name="test-bucket-with-roles",
+        iam_names_prefix="TestBucket",
+        iam_read_root_name="Restore",
+        iam_write_root_name="Push",
+        iam_path="/test/",
+        read_trusted_accounts=["123456789"],
+        write_trusted_accounts=["987654321"],
+    )
+    stack.add(bucket)
+
+    with open(os.path.join(TEST_DIR, "bucket-with-roles-trusted-accounts.json")) as fd:
+        expected_template = json.load(fd)
+
+    assert stack.export()["Resources"] == expected_template
+
+
 def test_bucket_multi_encryption(stack: Stack) -> None:
     """Test bucket accepting multiple types of encryptions and without default."""
     bucket = Bucket(


### PR DESCRIPTION
The parameter trusted_accounts of BucketWithRoles only allows to pass a list of accounts to be trusted both for read access and write access. However, it may sometimes be desirable to only trust an account for read access. Here we add two parameters that can be used to trust additional accounts only for read access or write access