### PR TITLE
Add Retain as deletion policy for buckets

### DIFF
--- a/src/e3/aws/troposphere/s3/bucket.py
+++ b/src/e3/aws/troposphere/s3/bucket.py
@@ -277,7 +277,7 @@ class Bucket(Construct):
         notification_config, notification_resources = self.notification_setup
         optional_resources.extend(notification_resources)
 
-        attr = {}
+        attr = {"DeletionPolicy": "Retain"}
         for key, val in {
             "BucketName": self.name,
             "BucketEncryption": bucket_encryption,

--- a/tests/tests_e3_aws/troposphere/config/config_test.py
+++ b/tests/tests_e3_aws/troposphere/config/config_test.py
@@ -131,6 +131,7 @@ EXPECTED_RECORDER = {
         "DependsOn": "AWSServiceRoleForConfig",
     },
     "ConfigTestBucket": {
+        "DeletionPolicy": "Retain",
         "Properties": {
             "BucketName": "config-test-bucket",
             "BucketEncryption": {

--- a/tests/tests_e3_aws/troposphere/s3/bucket-with-roles-trusted-accounts.json
+++ b/tests/tests_e3_aws/troposphere/s3/bucket-with-roles-trusted-accounts.json
@@ -1,5 +1,6 @@
 {
     "TestBucketWithRoles": {
+        "DeletionPolicy": "Retain",
         "Properties": {
             "BucketName": "test-bucket-with-roles",
             "BucketEncryption": {

--- a/tests/tests_e3_aws/troposphere/s3/bucket-with-roles.json
+++ b/tests/tests_e3_aws/troposphere/s3/bucket-with-roles.json
@@ -1,5 +1,6 @@
 {
     "TestBucketWithRoles": {
+        "DeletionPolicy": "Retain",
         "Properties": {
             "BucketName": "test-bucket-with-roles",
             "BucketEncryption": {

--- a/tests/tests_e3_aws/troposphere/s3/bucket.json
+++ b/tests/tests_e3_aws/troposphere/s3/bucket.json
@@ -29,6 +29,7 @@
         "Type": "AWS::Lambda::Function"
     },
     "TestBucket": {
+        "DeletionPolicy": "Retain",
         "Properties": {
             "BucketName": "test-bucket",
             "BucketEncryption": {

--- a/tests/tests_e3_aws/troposphere/s3/bucket_multi_encryption.json
+++ b/tests/tests_e3_aws/troposphere/s3/bucket_multi_encryption.json
@@ -1,5 +1,6 @@
 {
     "TestBucket": {
+        "DeletionPolicy": "Retain",
         "Properties": {
             "BucketName": "test-bucket",
             "PublicAccessBlockConfiguration": {

--- a/tests/tests_e3_aws/troposphere/s3/bucket_notification_string_arns.json
+++ b/tests/tests_e3_aws/troposphere/s3/bucket_notification_string_arns.json
@@ -1,5 +1,6 @@
 {
     "TestBucket": {
+        "DeletionPolicy": "Retain",
         "Properties": {
             "BucketName": "test-bucket",
             "BucketEncryption": {

--- a/tests/tests_e3_aws/troposphere/s3websitedistribution.json
+++ b/tests/tests_e3_aws/troposphere/s3websitedistribution.json
@@ -1,5 +1,6 @@
 {
     "HostBucket": {
+        "DeletionPolicy": "Retain",
         "Properties": {
             "BucketName": "host-bucket",
             "BucketEncryption": {

--- a/tests/tests_e3_aws/troposphere/s3websitedistribution_bucket.json
+++ b/tests/tests_e3_aws/troposphere/s3websitedistribution_bucket.json
@@ -1,5 +1,6 @@
 {
     "HostBucket": {
+        "DeletionPolicy": "Retain",
         "Properties": {
             "BucketName": "host-bucket",
             "BucketEncryption": {

--- a/tests/tests_e3_aws/troposphere/s3websitedistribution_iam_path.json
+++ b/tests/tests_e3_aws/troposphere/s3websitedistribution_iam_path.json
@@ -1,5 +1,6 @@
 {
     "HostBucket": {
+        "DeletionPolicy": "Retain",
         "Properties": {
             "BucketName": "host-bucket",
             "BucketEncryption": {

--- a/tests/tests_e3_aws/troposphere/s3websitedistribution_logging.json
+++ b/tests/tests_e3_aws/troposphere/s3websitedistribution_logging.json
@@ -1,5 +1,6 @@
 {
     "HostBucket": {
+        "DeletionPolicy": "Retain",
         "Properties": {
             "BucketName": "host-bucket",
             "BucketEncryption": {

--- a/tests/tests_e3_aws/troposphere/s3websitedistribution_logging_default.json
+++ b/tests/tests_e3_aws/troposphere/s3websitedistribution_logging_default.json
@@ -1,5 +1,6 @@
 {
     "HostBucket": {
+        "DeletionPolicy": "Retain",
         "Properties": {
             "BucketName": "host-bucket",
             "BucketEncryption": {

--- a/tests/tests_e3_aws/troposphere/stack/stack_with_outputs.json
+++ b/tests/tests_e3_aws/troposphere/stack/stack_with_outputs.json
@@ -1,5 +1,6 @@
 {
     "MyBucket": {
+        "DeletionPolicy": "Retain",
         "Properties": {
             "BucketName": "my-bucket",
             "BucketEncryption": {


### PR DESCRIPTION
Set retain as deletion policy for buckets so that cloudformation either does not try to delete buckets during rollbacks or so that if the bucket exists it can be imported.