### PR TITLE
Perform a second sed for scripts_user module

### DIFF
--- a/src/e3/aws/cfn/ec2/__init__.py
+++ b/src/e3/aws/cfn/ec2/__init__.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 
 CFN_INIT_STARTUP_SCRIPT = """#!/bin/sh
 sed -i 's/scripts-user$/[scripts-user, always]/' /etc/cloud/cloud.cfg
+sed -i 's/scripts_user$/[scripts_user, always]/' /etc/cloud/cloud.cfg
 ${Cfninit} -v --stack ${AWS::StackName} \\
                 --region ${AWS::Region} \\
                 --resource ${Resource} \\


### PR DESCRIPTION
Following a change in cloud-init the module that controls user_data has been renamed from "scripts-user" to "scripts_user", to take this change into account we add a second sed to CFN_INIT_STARTUP_SCRIPT.