### PR TITLE
Fix RestApi referencing $default in LambdaPermission

### DIFF
--- a/tests/tests_e3_aws/troposphere/apigateway/apigateway_test.py
+++ b/tests/tests_e3_aws/troposphere/apigateway/apigateway_test.py
@@ -529,7 +529,7 @@ def test_rest_api_stages(stack: Stack, lambda_fun: PyFunction) -> None:
             Method("ANY"),
         ],
         stages_config=[
-            StageConfiguration("$default"),
+            StageConfiguration("default"),
             StageConfiguration(
                 "beta", api_mapping_key="beta", variables={"somevar": "somevalue"}
             ),
@@ -574,7 +574,7 @@ def test_rest_api_lambda_alias(stack: Stack, lambda_fun: PyFunction) -> None:
         ],
         stages_config=[
             StageConfiguration(
-                "$default",
+                "default",
                 lambda_arn_permission=lambda_aliases.blue.ref,
                 variables={"lambdaAlias": lambda_aliases.blue.name},
             ),
@@ -667,7 +667,7 @@ def test_rest_api_custom_domain_stages(stack: Stack, lambda_fun: PyFunction) -> 
             Method("ANY", authorizer_name="testauthorizer"),
         ],
         stages_config=[
-            StageConfiguration("$default"),
+            StageConfiguration("default"),
             StageConfiguration(
                 "beta", api_mapping_key="beta", variables={"somevar": "somevalue"}
             ),

--- a/tests/tests_e3_aws/troposphere/apigateway/apigatewayv1_test.json
+++ b/tests/tests_e3_aws/troposphere/apigateway/apigatewayv1_test.json
@@ -45,7 +45,7 @@
     },
     "TestapiDefaultDeployment": {
         "Properties": {
-            "Description": "Deployment resource of $default stage",
+            "Description": "Deployment resource of default stage",
             "RestApiId": {
                 "Ref": "Testapi"
             }
@@ -72,7 +72,7 @@
             "DeploymentId": {
                 "Ref": "TestapiDefaultDeployment"
             },
-            "Description": "stage $default",
+            "Description": "stage default",
             "MethodSettings": [
                 {
                     "ResourcePath": "/*",
@@ -116,7 +116,7 @@
         },
         "Type": "AWS::ApiGateway::Method"
     },
-    "TestapiANYLambdaPermission": {
+    "TestapiANYDefaultLambdaPermission": {
         "Properties": {
             "Action": "lambda:InvokeFunction",
             "FunctionName": {
@@ -125,7 +125,7 @@
             "Principal": "apigateway.amazonaws.com",
             "SourceArn": {
                 "Fn::Sub": [
-                    "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${api}/$default/${method}/*",
+                    "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${api}/default/${method}/*",
                     {
                         "api": {
                             "Ref": "Testapi"

--- a/tests/tests_e3_aws/troposphere/apigateway/apigatewayv1_test_custom_domain.json
+++ b/tests/tests_e3_aws/troposphere/apigateway/apigatewayv1_test_custom_domain.json
@@ -71,7 +71,7 @@
     },
     "TestapiDefaultDeployment": {
         "Properties": {
-            "Description": "Deployment resource of $default stage",
+            "Description": "Deployment resource of default stage",
             "RestApiId": {
                 "Ref": "Testapi"
             }
@@ -98,7 +98,7 @@
             "DeploymentId": {
                 "Ref": "TestapiDefaultDeployment"
             },
-            "Description": "stage $default",
+            "Description": "stage default",
             "MethodSettings": [
                 {
                     "ResourcePath": "/*",
@@ -145,7 +145,7 @@
         },
         "Type": "AWS::ApiGateway::Method"
     },
-    "TestapiANYLambdaPermission": {
+    "TestapiANYDefaultLambdaPermission": {
         "Properties": {
             "Action": "lambda:InvokeFunction",
             "FunctionName": {
@@ -154,7 +154,7 @@
             "Principal": "apigateway.amazonaws.com",
             "SourceArn": {
                 "Fn::Sub": [
-                    "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${api}/$default/${method}/*",
+                    "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${api}/default/${method}/*",
                     {
                         "api": {
                             "Ref": "Testapi"
@@ -188,7 +188,7 @@
         },
         "Type": "AWS::ApiGateway::DomainName"
     },
-    "TestapiapiexamplecomBasePathMapping": {
+    "TestapiapiexamplecomDefaultBasePathMapping": {
         "Properties": {
             "DomainName": {
                 "Ref": "TestapiapiexamplecomDomain"

--- a/tests/tests_e3_aws/troposphere/apigateway/apigatewayv1_test_custom_domain_stages.json
+++ b/tests/tests_e3_aws/troposphere/apigateway/apigatewayv1_test_custom_domain_stages.json
@@ -71,7 +71,7 @@
     },
     "TestapiDefaultDeployment": {
         "Properties": {
-            "Description": "Deployment resource of $default stage",
+            "Description": "Deployment resource of default stage",
             "RestApiId": {
                 "Ref": "Testapi"
             }
@@ -98,7 +98,7 @@
             "DeploymentId": {
                 "Ref": "TestapiDefaultDeployment"
             },
-            "Description": "stage $default",
+            "Description": "stage default",
             "MethodSettings": [
                 {
                     "ResourcePath": "/*",
@@ -212,7 +212,7 @@
         },
         "Type": "AWS::Lambda::Permission"
     },
-    "TestapiANYLambdaPermission": {
+    "TestapiANYDefaultLambdaPermission": {
         "Properties": {
             "Action": "lambda:InvokeFunction",
             "FunctionName": {
@@ -221,7 +221,7 @@
             "Principal": "apigateway.amazonaws.com",
             "SourceArn": {
                 "Fn::Sub": [
-                    "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${api}/$default/${method}/*",
+                    "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${api}/default/${method}/*",
                     {
                         "api": {
                             "Ref": "Testapi"
@@ -255,7 +255,7 @@
         },
         "Type": "AWS::ApiGateway::DomainName"
     },
-    "TestapiapiexamplecomBasePathMapping": {
+    "TestapiapiexamplecomDefaultBasePathMapping": {
         "Properties": {
             "DomainName": {
                 "Ref": "TestapiapiexamplecomDomain"

--- a/tests/tests_e3_aws/troposphere/apigateway/apigatewayv1_test_lambda_alias.json
+++ b/tests/tests_e3_aws/troposphere/apigateway/apigatewayv1_test_lambda_alias.json
@@ -91,7 +91,7 @@
     },
     "TestapiDefaultDeployment": {
         "Properties": {
-            "Description": "Deployment resource of $default stage",
+            "Description": "Deployment resource of default stage",
             "RestApiId": {
                 "Ref": "Testapi"
             }
@@ -118,7 +118,7 @@
             "DeploymentId": {
                 "Ref": "TestapiDefaultDeployment"
             },
-            "Description": "stage $default",
+            "Description": "stage default",
             "MethodSettings": [
                 {
                     "ResourcePath": "/*",
@@ -177,7 +177,7 @@
         },
         "Type": "AWS::Lambda::Permission"
     },
-    "TestapiANYLambdaPermission": {
+    "TestapiANYDefaultLambdaPermission": {
         "Properties": {
             "Action": "lambda:InvokeFunction",
             "FunctionName": {
@@ -186,7 +186,7 @@
             "Principal": "apigateway.amazonaws.com",
             "SourceArn": {
                 "Fn::Sub": [
-                    "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${api}/$default/${method}/*",
+                    "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${api}/default/${method}/*",
                     {
                         "api": {
                             "Ref": "Testapi"

--- a/tests/tests_e3_aws/troposphere/apigateway/apigatewayv1_test_nested_resources.json
+++ b/tests/tests_e3_aws/troposphere/apigateway/apigatewayv1_test_nested_resources.json
@@ -75,7 +75,7 @@
     },
     "TestapiDefaultDeployment": {
         "Properties": {
-            "Description": "Deployment resource of $default stage",
+            "Description": "Deployment resource of default stage",
             "RestApiId": {
                 "Ref": "Testapi"
             }
@@ -104,7 +104,7 @@
             "DeploymentId": {
                 "Ref": "TestapiDefaultDeployment"
             },
-            "Description": "stage $default",
+            "Description": "stage default",
             "MethodSettings": [
                 {
                     "ResourcePath": "/*",
@@ -208,7 +208,7 @@
         },
         "Type": "AWS::ApiGateway::Method"
     },
-    "TestapiAccountsANYLambdaPermission": {
+    "TestapiAccountsANYDefaultLambdaPermission": {
         "Properties": {
             "Action": "lambda:InvokeFunction",
             "FunctionName": {
@@ -217,7 +217,7 @@
             "Principal": "apigateway.amazonaws.com",
             "SourceArn": {
                 "Fn::Sub": [
-                    "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${api}/$default/${method}/accounts",
+                    "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${api}/default/${method}/accounts",
                     {
                         "api": {
                             "Ref": "Testapi"
@@ -229,7 +229,7 @@
         },
         "Type": "AWS::Lambda::Permission"
     },
-    "TestapiProductsANYLambdaPermission": {
+    "TestapiProductsANYDefaultLambdaPermission": {
         "Properties": {
             "Action": "lambda:InvokeFunction",
             "FunctionName": {
@@ -238,7 +238,7 @@
             "Principal": "apigateway.amazonaws.com",
             "SourceArn": {
                 "Fn::Sub": [
-                    "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${api}/$default/${method}/products",
+                    "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${api}/default/${method}/products",
                     {
                         "api": {
                             "Ref": "Testapi"
@@ -250,7 +250,7 @@
         },
         "Type": "AWS::Lambda::Permission"
     },
-    "TestapiProductsAbcdANYLambdaPermission": {
+    "TestapiProductsAbcdANYDefaultLambdaPermission": {
         "Properties": {
             "Action": "lambda:InvokeFunction",
             "FunctionName": {
@@ -259,7 +259,7 @@
             "Principal": "apigateway.amazonaws.com",
             "SourceArn": {
                 "Fn::Sub": [
-                    "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${api}/$default/${method}/products/abcd",
+                    "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${api}/default/${method}/products/abcd",
                     {
                         "api": {
                             "Ref": "Testapi"

--- a/tests/tests_e3_aws/troposphere/apigateway/apigatewayv1_test_stages.json
+++ b/tests/tests_e3_aws/troposphere/apigateway/apigatewayv1_test_stages.json
@@ -91,7 +91,7 @@
     },
     "TestapiDefaultDeployment": {
         "Properties": {
-            "Description": "Deployment resource of $default stage",
+            "Description": "Deployment resource of default stage",
             "RestApiId": {
                 "Ref": "Testapi"
             }
@@ -118,7 +118,7 @@
             "DeploymentId": {
                 "Ref": "TestapiDefaultDeployment"
             },
-            "Description": "stage $default",
+            "Description": "stage default",
             "MethodSettings": [
                 {
                     "ResourcePath": "/*",
@@ -183,7 +183,7 @@
         },
         "Type": "AWS::Lambda::Permission"
     },
-    "TestapiANYLambdaPermission": {
+    "TestapiANYDefaultLambdaPermission": {
         "Properties": {
             "Action": "lambda:InvokeFunction",
             "FunctionName": {
@@ -192,7 +192,7 @@
             "Principal": "apigateway.amazonaws.com",
             "SourceArn": {
                 "Fn::Sub": [
-                    "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${api}/$default/${method}/*",
+                    "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${api}/default/${method}/*",
                     {
                         "api": {
                             "Ref": "Testapi"


### PR DESCRIPTION
Apigateway v1 doesn't allow $ in the stage name and so it was removed when declaring the stage, while still used in the LambdaPermission.

Also remove the special case that prevented having Default in the name of some resources