### PR TITLE
Improve RestApi for stages and aliases

### DIFF
--- a/tests/tests_e3_aws/troposphere/apigateway/apigatewayv1_test_multi_lambdas_stages.json
+++ b/tests/tests_e3_aws/troposphere/apigateway/apigatewayv1_test_multi_lambdas_stages.json
@@ -1,0 +1,420 @@
+{
+    "Accountslambda": {
+        "Properties": {
+            "Code": {
+                "S3Bucket": "cfn_bucket",
+                "S3Key": "templates/accountslambda_lambda.zip"
+            },
+            "Timeout": 3,
+            "Description": "this is a test",
+            "Role": "somearn",
+            "FunctionName": "accountslambda",
+            "Runtime": "python3.8",
+            "Handler": "app.main"
+        },
+        "Type": "AWS::Lambda::Function"
+    },
+    "Productslambda": {
+        "Properties": {
+            "Code": {
+                "S3Bucket": "cfn_bucket",
+                "S3Key": "templates/productslambda_lambda.zip"
+            },
+            "Timeout": 3,
+            "Description": "this is a test",
+            "Role": "somearn",
+            "FunctionName": "productslambda",
+            "Runtime": "python3.8",
+            "Handler": "app.main"
+        },
+        "Type": "AWS::Lambda::Function"
+    },
+    "AccountslambdaVersion1": {
+        "Properties": {
+            "Description": "version 1 of accountslambda lambda",
+            "FunctionName": {
+                "Fn::GetAtt": [
+                    "Accountslambda",
+                    "Arn"
+                ]
+            }
+        },
+        "Type": "AWS::Lambda::Version"
+    },
+    "AccountslambdaVersion2": {
+        "Properties": {
+            "Description": "version 2 of accountslambda lambda",
+            "FunctionName": {
+                "Fn::GetAtt": [
+                    "Accountslambda",
+                    "Arn"
+                ]
+            }
+        },
+        "Type": "AWS::Lambda::Version"
+    },
+    "ProductslambdaVersion1": {
+        "Properties": {
+            "Description": "version 1 of productslambda lambda",
+            "FunctionName": {
+                "Fn::GetAtt": [
+                    "Productslambda",
+                    "Arn"
+                ]
+            }
+        },
+        "Type": "AWS::Lambda::Version"
+    },
+    "ProductslambdaVersion2": {
+        "Properties": {
+            "Description": "version 2 of productslambda lambda",
+            "FunctionName": {
+                "Fn::GetAtt": [
+                    "Productslambda",
+                    "Arn"
+                ]
+            }
+        },
+        "Type": "AWS::Lambda::Version"
+    },
+    "AccountslambdaBlueAlias": {
+        "Properties": {
+            "Description": "Blue alias for accountslambda lambda",
+            "FunctionName": {
+                "Fn::GetAtt": [
+                    "Accountslambda",
+                    "Arn"
+                ]
+            },
+            "FunctionVersion": {
+                "Fn::GetAtt": [
+                    "AccountslambdaVersion1",
+                    "Version"
+                ]
+            },
+            "Name": "Blue"
+        },
+        "Type": "AWS::Lambda::Alias"
+    },
+    "AccountslambdaGreenAlias": {
+        "Properties": {
+            "Description": "Green alias for accountslambda lambda",
+            "FunctionName": {
+                "Fn::GetAtt": [
+                    "Accountslambda",
+                    "Arn"
+                ]
+            },
+            "FunctionVersion": {
+                "Fn::GetAtt": [
+                    "AccountslambdaVersion2",
+                    "Version"
+                ]
+            },
+            "Name": "Green"
+        },
+        "Type": "AWS::Lambda::Alias"
+    },
+    "ProductslambdaBlueAlias": {
+        "Properties": {
+            "Description": "Blue alias for productslambda lambda",
+            "FunctionName": {
+                "Fn::GetAtt": [
+                    "Productslambda",
+                    "Arn"
+                ]
+            },
+            "FunctionVersion": {
+                "Fn::GetAtt": [
+                    "ProductslambdaVersion1",
+                    "Version"
+                ]
+            },
+            "Name": "Blue"
+        },
+        "Type": "AWS::Lambda::Alias"
+    },
+    "ProductslambdaGreenAlias": {
+        "Properties": {
+            "Description": "Green alias for productslambda lambda",
+            "FunctionName": {
+                "Fn::GetAtt": [
+                    "Productslambda",
+                    "Arn"
+                ]
+            },
+            "FunctionVersion": {
+                "Fn::GetAtt": [
+                    "ProductslambdaVersion2",
+                    "Version"
+                ]
+            },
+            "Name": "Green"
+        },
+        "Type": "AWS::Lambda::Alias"
+    },
+    "TestapiLogGroup": {
+        "Properties": {
+            "LogGroupName": "testapi"
+        },
+        "Type": "AWS::Logs::LogGroup"
+    },
+    "Testapi": {
+        "Properties": {
+            "Description": "this is a test",
+            "Name": "testapi",
+            "DisableExecuteApiEndpoint": false
+        },
+        "Type": "AWS::ApiGateway::RestApi"
+    },
+    "TestapiAccountsResource": {
+        "Properties": {
+            "ParentId": {
+                "Fn::GetAtt": [
+                    "Testapi",
+                    "RootResourceId"
+                ]
+            },
+            "RestApiId": {
+                "Ref": "Testapi"
+            },
+            "PathPart": "accounts"
+        },
+        "Type": "AWS::ApiGateway::Resource"
+    },
+    "TestapiProductsResource": {
+        "Properties": {
+            "ParentId": {
+                "Fn::GetAtt": [
+                    "Testapi",
+                    "RootResourceId"
+                ]
+            },
+            "RestApiId": {
+                "Ref": "Testapi"
+            },
+            "PathPart": "products"
+        },
+        "Type": "AWS::ApiGateway::Resource"
+    },
+    "TestapiDefaultDeployment": {
+        "Properties": {
+            "Description": "Deployment resource of default stage",
+            "RestApiId": {
+                "Ref": "Testapi"
+            }
+        },
+        "Type": "AWS::ApiGateway::Deployment",
+        "DependsOn": [
+            "TestapiAccountsANYMethod",
+            "TestapiProductsANYMethod"
+        ]
+    },
+    "TestapiBetaDeployment": {
+        "Properties": {
+            "Description": "Deployment resource of beta stage",
+            "RestApiId": {
+                "Ref": "Testapi"
+            }
+        },
+        "Type": "AWS::ApiGateway::Deployment",
+        "DependsOn": [
+            "TestapiAccountsANYMethod",
+            "TestapiProductsANYMethod"
+        ]
+    },
+    "TestapiDefaultStage": {
+        "Properties": {
+            "AccessLogSetting": {
+                "DestinationArn": {
+                    "Fn::GetAtt": [
+                        "TestapiLogGroup",
+                        "Arn"
+                    ]
+                },
+                "Format": "{\"source_ip\": \"$context.identity.sourceIp\", \"request_time\": \"$context.requestTime\", \"method\": \"$context.httpMethod\", \"route\": \"$context.routeKey\", \"protocol\": \"$context.protocol\", \"status\": \"$context.status\", \"response_length\": \"$context.responseLength\", \"request_id\": \"$context.requestId\", \"integration_error_msg\": \"$context.integrationErrorMessage\"}"
+            },
+            "RestApiId": {
+                "Ref": "Testapi"
+            },
+            "DeploymentId": {
+                "Ref": "TestapiDefaultDeployment"
+            },
+            "Description": "stage default",
+            "MethodSettings": [
+                {
+                    "ResourcePath": "/*",
+                    "HttpMethod": "*",
+                    "MetricsEnabled": true,
+                    "ThrottlingBurstLimit": 10,
+                    "ThrottlingRateLimit": 10
+                }
+            ],
+            "StageName": "default",
+            "Variables": {
+                "lambdaAlias": "Blue"
+            }
+        },
+        "Type": "AWS::ApiGateway::Stage"
+    },
+    "TestapiBetaStage": {
+        "Properties": {
+            "AccessLogSetting": {
+                "DestinationArn": {
+                    "Fn::GetAtt": [
+                        "TestapiLogGroup",
+                        "Arn"
+                    ]
+                },
+                "Format": "{\"source_ip\": \"$context.identity.sourceIp\", \"request_time\": \"$context.requestTime\", \"method\": \"$context.httpMethod\", \"route\": \"$context.routeKey\", \"protocol\": \"$context.protocol\", \"status\": \"$context.status\", \"response_length\": \"$context.responseLength\", \"request_id\": \"$context.requestId\", \"integration_error_msg\": \"$context.integrationErrorMessage\"}"
+            },
+            "RestApiId": {
+                "Ref": "Testapi"
+            },
+            "DeploymentId": {
+                "Ref": "TestapiBetaDeployment"
+            },
+            "Description": "stage beta",
+            "MethodSettings": [
+                {
+                    "ResourcePath": "/*",
+                    "HttpMethod": "*",
+                    "MetricsEnabled": true,
+                    "ThrottlingBurstLimit": 10,
+                    "ThrottlingRateLimit": 10
+                }
+            ],
+            "StageName": "beta",
+            "Variables": {
+                "lambdaAlias": "Green"
+            }
+        },
+        "Type": "AWS::ApiGateway::Stage"
+    },
+    "TestapiAccountsANYMethod": {
+        "Properties": {
+            "RestApiId": {
+                "Ref": "Testapi"
+            },
+            "AuthorizationType": "NONE",
+            "HttpMethod": "ANY",
+            "Integration": {
+                "CacheKeyParameters": [],
+                "CacheNamespace": "none",
+                "IntegrationHttpMethod": "POST",
+                "PassthroughBehavior": "NEVER",
+                "Type": "AWS_PROXY",
+                "Uri": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:eu-west-1:123456789012:function:accountslambda:${stageVariables.lambdaAlias}/invocations"
+            },
+            "ResourceId": {
+                "Ref": "TestapiAccountsResource"
+            }
+        },
+        "Type": "AWS::ApiGateway::Method"
+    },
+    "TestapiProductsANYMethod": {
+        "Properties": {
+            "RestApiId": {
+                "Ref": "Testapi"
+            },
+            "AuthorizationType": "NONE",
+            "HttpMethod": "ANY",
+            "Integration": {
+                "CacheKeyParameters": [],
+                "CacheNamespace": "none",
+                "IntegrationHttpMethod": "POST",
+                "PassthroughBehavior": "NEVER",
+                "Type": "AWS_PROXY",
+                "Uri": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:eu-west-1:123456789012:function:productslambda:${stageVariables.lambdaAlias}/invocations"
+            },
+            "ResourceId": {
+                "Ref": "TestapiProductsResource"
+            }
+        },
+        "Type": "AWS::ApiGateway::Method"
+    },
+    "TestapiAccountsANYDefaultLambdaPermission": {
+        "Properties": {
+            "Action": "lambda:InvokeFunction",
+            "FunctionName": {
+                "Ref": "AccountslambdaBlueAlias"
+            },
+            "Principal": "apigateway.amazonaws.com",
+            "SourceArn": {
+                "Fn::Sub": [
+                    "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${api}/default/${method}/accounts",
+                    {
+                        "api": {
+                            "Ref": "Testapi"
+                        },
+                        "method": "*"
+                    }
+                ]
+            }
+        },
+        "Type": "AWS::Lambda::Permission"
+    },
+    "TestapiAccountsANYBetaLambdaPermission": {
+        "Properties": {
+            "Action": "lambda:InvokeFunction",
+            "FunctionName": {
+                "Ref": "AccountslambdaGreenAlias"
+            },
+            "Principal": "apigateway.amazonaws.com",
+            "SourceArn": {
+                "Fn::Sub": [
+                    "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${api}/beta/${method}/accounts",
+                    {
+                        "api": {
+                            "Ref": "Testapi"
+                        },
+                        "method": "*"
+                    }
+                ]
+            }
+        },
+        "Type": "AWS::Lambda::Permission"
+    },
+    "TestapiProductsANYDefaultLambdaPermission": {
+        "Properties": {
+            "Action": "lambda:InvokeFunction",
+            "FunctionName": {
+                "Ref": "ProductslambdaBlueAlias"
+            },
+            "Principal": "apigateway.amazonaws.com",
+            "SourceArn": {
+                "Fn::Sub": [
+                    "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${api}/default/${method}/products",
+                    {
+                        "api": {
+                            "Ref": "Testapi"
+                        },
+                        "method": "*"
+                    }
+                ]
+            }
+        },
+        "Type": "AWS::Lambda::Permission"
+    },
+    "TestapiProductsANYBetaLambdaPermission": {
+        "Properties": {
+            "Action": "lambda:InvokeFunction",
+            "FunctionName": {
+                "Ref": "ProductslambdaGreenAlias"
+            },
+            "Principal": "apigateway.amazonaws.com",
+            "SourceArn": {
+                "Fn::Sub": [
+                    "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${api}/beta/${method}/products",
+                    {
+                        "api": {
+                            "Ref": "Testapi"
+                        },
+                        "method": "*"
+                    }
+                ]
+            }
+        },
+        "Type": "AWS::Lambda::Permission"
+    }
+}

--- a/tests/tests_e3_aws/troposphere/apigateway/apigatewayv1_test_nested_resources.json
+++ b/tests/tests_e3_aws/troposphere/apigateway/apigatewayv1_test_nested_resources.json
@@ -28,7 +28,7 @@
         },
         "Type": "AWS::ApiGateway::RestApi"
     },
-    "TestapiAccountsResource": {
+    "TestapiFooResource": {
         "Properties": {
             "ParentId": {
                 "Fn::GetAtt": [
@@ -39,37 +39,22 @@
             "RestApiId": {
                 "Ref": "Testapi"
             },
-            "PathPart": "accounts"
+            "PathPart": "foo"
         },
         "Type": "AWS::ApiGateway::Resource"
     },
-    "TestapiProductsResource": {
+    "TestapiFooBarResource": {
         "Properties": {
             "ParentId": {
                 "Fn::GetAtt": [
-                    "Testapi",
-                    "RootResourceId"
-                ]
-            },
-            "RestApiId": {
-                "Ref": "Testapi"
-            },
-            "PathPart": "products"
-        },
-        "Type": "AWS::ApiGateway::Resource"
-    },
-    "TestapiProductsAbcdResource": {
-        "Properties": {
-            "ParentId": {
-                "Fn::GetAtt": [
-                    "TestapiProductsResource",
+                    "TestapiFooResource",
                     "ResourceId"
                 ]
             },
             "RestApiId": {
                 "Ref": "Testapi"
             },
-            "PathPart": "abcd"
+            "PathPart": "bar"
         },
         "Type": "AWS::ApiGateway::Resource"
     },
@@ -82,9 +67,8 @@
         },
         "Type": "AWS::ApiGateway::Deployment",
         "DependsOn": [
-            "TestapiAccountsANYMethod",
-            "TestapiProductsANYMethod",
-            "TestapiProductsAbcdGETMethod"
+            "TestapiFooANYMethod",
+            "TestapiFooBarGETMethod"
         ]
     },
     "TestapiDefaultStage": {
@@ -118,7 +102,7 @@
         },
         "Type": "AWS::ApiGateway::Stage"
     },
-    "TestapiAccountsANYMethod": {
+    "TestapiFooANYMethod": {
         "Properties": {
             "RestApiId": {
                 "Ref": "Testapi"
@@ -143,42 +127,12 @@
                 }
             },
             "ResourceId": {
-                "Ref": "TestapiAccountsResource"
+                "Ref": "TestapiFooResource"
             }
         },
         "Type": "AWS::ApiGateway::Method"
     },
-    "TestapiProductsANYMethod": {
-        "Properties": {
-            "RestApiId": {
-                "Ref": "Testapi"
-            },
-            "AuthorizationType": "NONE",
-            "HttpMethod": "ANY",
-            "Integration": {
-                "CacheKeyParameters": [],
-                "CacheNamespace": "none",
-                "IntegrationHttpMethod": "POST",
-                "PassthroughBehavior": "NEVER",
-                "Type": "AWS_PROXY",
-                "Uri": {
-                    "Fn::Sub": [
-                        "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${lambdaArn}/invocations",
-                        {
-                            "lambdaArn": {
-                                "Ref": "Productslambda"
-                            }
-                        }
-                    ]
-                }
-            },
-            "ResourceId": {
-                "Ref": "TestapiProductsResource"
-            }
-        },
-        "Type": "AWS::ApiGateway::Method"
-    },
-    "TestapiProductsAbcdGETMethod": {
+    "TestapiFooBarGETMethod": {
         "Properties": {
             "RestApiId": {
                 "Ref": "Testapi"
@@ -203,12 +157,12 @@
                 }
             },
             "ResourceId": {
-                "Ref": "TestapiProductsAbcdResource"
+                "Ref": "TestapiFooBarResource"
             }
         },
         "Type": "AWS::ApiGateway::Method"
     },
-    "TestapiAccountsANYDefaultLambdaPermission": {
+    "TestapiFooANYDefaultLambdaPermission": {
         "Properties": {
             "Action": "lambda:InvokeFunction",
             "FunctionName": {
@@ -217,7 +171,7 @@
             "Principal": "apigateway.amazonaws.com",
             "SourceArn": {
                 "Fn::Sub": [
-                    "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${api}/default/${method}/accounts",
+                    "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${api}/default/${method}/foo",
                     {
                         "api": {
                             "Ref": "Testapi"
@@ -229,28 +183,7 @@
         },
         "Type": "AWS::Lambda::Permission"
     },
-    "TestapiProductsANYDefaultLambdaPermission": {
-        "Properties": {
-            "Action": "lambda:InvokeFunction",
-            "FunctionName": {
-                "Ref": "Productslambda"
-            },
-            "Principal": "apigateway.amazonaws.com",
-            "SourceArn": {
-                "Fn::Sub": [
-                    "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${api}/default/${method}/products",
-                    {
-                        "api": {
-                            "Ref": "Testapi"
-                        },
-                        "method": "*"
-                    }
-                ]
-            }
-        },
-        "Type": "AWS::Lambda::Permission"
-    },
-    "TestapiProductsAbcdGETDefaultLambdaPermission": {
+    "TestapiFooBarGETDefaultLambdaPermission": {
         "Properties": {
             "Action": "lambda:InvokeFunction",
             "FunctionName": {
@@ -259,7 +192,7 @@
             "Principal": "apigateway.amazonaws.com",
             "SourceArn": {
                 "Fn::Sub": [
-                    "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${api}/default/${method}/products/abcd",
+                    "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${api}/default/${method}/foo/bar",
                     {
                         "api": {
                             "Ref": "Testapi"

--- a/tests/tests_e3_aws/troposphere/awslambda/awslambda_test.py
+++ b/tests/tests_e3_aws/troposphere/awslambda/awslambda_test.py
@@ -284,7 +284,7 @@ EXPECTED_BLUEGREENALIASES_DEFAULT_TEMPLATE = {
 EXPECTED_BLUEGREENALIASES_TEMPLATE = {
     "MypylambdaProdAlias": {
         "Properties": {
-            "Name": "MypylambdaProdAlias",
+            "Name": "prod",
             "Description": "prod alias for mypylambda lambda",
             "FunctionName": {"Fn::GetAtt": ["Mypylambda", "Arn"]},
             "FunctionVersion": {"Ref": "MypylambdaVersion1"},
@@ -304,7 +304,7 @@ EXPECTED_BLUEGREENALIASES_TEMPLATE = {
     },
     "MypylambdaBetaAlias": {
         "Properties": {
-            "Name": "MypylambdaBetaAlias",
+            "Name": "beta",
             "Description": "beta alias for mypylambda lambda",
             "FunctionName": {"Fn::GetAtt": ["Mypylambda", "Arn"]},
             "FunctionVersion": {"Ref": "MypylambdaVersion2"},


### PR DESCRIPTION
The possibility to have different lambda functions depending on REST API methods doesn't integrate well with the current way of defining stages and lambda aliases.

As each stage is defined once, the stage variables must be the same for all methods and all lambda functions. So if there is a stage variable pointing to a lambda alias, it must be the same for all lambda functions.

Hence a change is made to Alias so that the resource name can be different from the alias name, and multiple lambda functions can share the same alias name.

Then the possibility to define an integration uri at the resource level is added so that each resource can point to a different lambda function while still referencing the stage variable containing the alias name.

Finally, the possibility to define the lambda ARN for the InvokeFunction permission at the resource level, and per stage, is added to make it possible to give the right permissions for each resource and stage.

Simplify test_rest_api_nested_resources as there is now test_rest_api_multi_lambdas_stages