### PR TITLE
Add read/write trusted policies parameters

### DIFF
--- a/src/e3/aws/troposphere/s3/__init__.py
+++ b/src/e3/aws/troposphere/s3/__init__.py
@@ -5,13 +5,21 @@ from typing import TYPE_CHECKING
 
 from e3.aws.troposphere import Construct
 from e3.aws.troposphere.iam.managed_policy import ManagedPolicy
-from e3.aws.troposphere.iam.policy_statement import Allow, Trust
+
+from e3.aws.troposphere.iam.policy_document import PolicyDocument
+from e3.aws.troposphere.iam.policy_statement import (
+    Allow,
+    Trust,
+    AssumeRole,
+    PolicyStatement,
+)
 from e3.aws.troposphere.iam.role import Role
 from e3.aws.troposphere.s3.bucket import Bucket
 
 if TYPE_CHECKING:
     from typing import Any
     from troposphere import AWSObject, Stack
+    from e3.aws.troposphere.iam.policy_statement import PrincipalType
 
 
 class BucketWithRoles(Construct):
@@ -23,11 +31,26 @@ class BucketWithRoles(Construct):
         iam_names_prefix: str,
         iam_path: str,
         trusted_accounts: list[str] | None = None,
+        trust_policy: PrincipalType
+        | list[PolicyStatement]
+        | PolicyStatement
+        | PolicyDocument
+        | None = None,
         iam_read_root_name: str = "Read",
         iam_write_root_name: str = "Write",
         bucket_exists: bool | None = None,
         read_trusted_accounts: list[str] | None = None,
         write_trusted_accounts: list[str] | None = None,
+        read_trust_policy: PrincipalType
+        | list[PolicyStatement]
+        | PolicyStatement
+        | PolicyDocument
+        | None = None,
+        write_trust_policy: PrincipalType
+        | list[PolicyStatement]
+        | PolicyStatement
+        | PolicyDocument
+        | None = None,
         **bucket_kwargs: Any,
     ) -> None:
         """Initialize BucketWithRoles instance.
@@ -36,13 +59,41 @@ class BucketWithRoles(Construct):
         :param iam_names_prefix: prefix for policies and roles names
         :param iam_path: path for iam resources
         :param trusted_accounts: accounts to be trusted by access roles
+        :param trust_policy: custom trust policy for access roles. It can be
+            either a principal, a list of statement or a policy document.
         :param iam_read_root_name: root name for read access roles and policy
         :param iam_write_root_name: root name for write access roles and policy
         :param bucket_exists: if True then the bucket is not created
         :param read_trusted_accounts: additional trusted accounts for read access
         :param write_trusted_accounts: additional trusted accounts for write access
+        :param read_trust_policy: additional custom trust policy for read access.
+            It can be either a principal, a list of statements or a policy document.
+        :param write_trust_policy: additional custom trust policy for write access.
+            It can be either a principal, a list of statements or a policy document.
         :param bucket_kwargs: keyword arguments to pass to the bucket constructor
         """
+        # check that only the accounts or the policy parameter are
+        # set not both
+        for el in [
+            {
+                f"{trust_policy=}".split("=")[0]: trust_policy,
+                f"{trusted_accounts=}".split("=")[0]: trusted_accounts,
+            },
+            {
+                f"{read_trust_policy=}".split("=")[0]: read_trust_policy,
+                f"{read_trusted_accounts=}".split("=")[0]: read_trusted_accounts,
+            },
+            {
+                f"{write_trust_policy=}".split("=")[0]: write_trust_policy,
+                f"{write_trusted_accounts=}".split("=")[0]: write_trusted_accounts,
+            },
+        ]:
+            if all(el.values()):
+                keys = list(el.keys())
+                raise AttributeError(
+                    f"You cannot set {keys[0]!r} and {keys[1]!r} at the"
+                    " same time , please use one or the other."
+                )
         self.name = name
         self.iam_names_prefix = iam_names_prefix
         self.trusted_accounts = trusted_accounts if trusted_accounts is not None else []
@@ -64,13 +115,7 @@ class BucketWithRoles(Construct):
             ],
             path=iam_path,
         )
-        self.read_role = Role(
-            name=f"{self.iam_names_prefix}{iam_read_root_name}Role",
-            description=f"Role with read access to {self.name} bucket.",
-            trust=Trust(accounts=self.trusted_accounts + self.read_trusted_accounts),
-            managed_policy_arns=[self.read_policy.arn],
-            path=iam_path,
-        )
+
         self.push_policy = ManagedPolicy(
             name=f"{self.iam_names_prefix}{iam_write_root_name}Policy",
             description=f"Grants write access permissions to {self.name} bucket",
@@ -82,10 +127,60 @@ class BucketWithRoles(Construct):
             ],
             path=iam_path,
         )
+
+        self.read_trust_policy = PolicyDocument(statements=[])
+        self.write_trust_policy = PolicyDocument(statements=[])
+
+        if self.trusted_accounts or self.read_trusted_accounts:
+            self.read_trust_policy += PolicyDocument(
+                statements=[
+                    Trust(accounts=self.trusted_accounts + self.read_trusted_accounts)
+                ]
+            )
+        if self.trusted_accounts or self.write_trusted_accounts:
+            self.write_trust_policy += PolicyDocument(
+                statements=[
+                    Trust(accounts=self.trusted_accounts + self.write_trusted_accounts)
+                ]
+            )
+
+        for policy_type, policy in [
+            (None, trust_policy),
+            ("read", read_trust_policy),
+            ("write", write_trust_policy),
+        ]:
+            if not policy:
+                continue
+
+            if isinstance(policy, list):
+                policy_document = PolicyDocument(statements=policy)
+            elif isinstance(policy, PolicyStatement):
+                policy_document = PolicyDocument(statements=[policy])
+            elif isinstance(policy, PolicyDocument):
+                policy_document = policy
+            else:
+                policy_document = PolicyDocument(
+                    statements=[AssumeRole(principal=policy)]
+                )
+
+            if policy_type in ("read", None):
+                self.read_trust_policy += policy_document
+
+            if policy_type in ("write", None):
+                self.write_trust_policy += policy_document
+
+        self.read_role = Role(
+            name=f"{self.iam_names_prefix}{iam_read_root_name}Role",
+            description=f"Role with read access to {self.name} bucket.",
+            trust=self.read_trust_policy,
+            managed_policy_arns=[self.read_policy.arn],
+            path=iam_path,
+        )
+
         self.push_role = Role(
             name=f"{self.iam_names_prefix}{iam_write_root_name}Role",
             description=f"Role with read and write access to {self.name} bucket.",
-            trust=Trust(accounts=self.trusted_accounts + self.write_trusted_accounts),
+            trust=self.write_trust_policy,
             managed_policy_arns=[self.push_policy.arn, self.read_policy.arn],
             path=iam_path,
         )

--- a/tests/tests_e3_aws/troposphere/s3/bucket-with-roles-trusted-policies.json
+++ b/tests/tests_e3_aws/troposphere/s3/bucket-with-roles-trusted-policies.json
@@ -1,0 +1,226 @@
+{
+    "TestBucketWithRoles": {
+        "Properties": {
+            "BucketName": "test-bucket-with-roles",
+            "BucketEncryption": {
+                "ServerSideEncryptionConfiguration": [
+                    {
+                        "ServerSideEncryptionByDefault": {
+                            "SSEAlgorithm": "AES256"
+                        }
+                    }
+                ]
+            },
+            "PublicAccessBlockConfiguration": {
+                "BlockPublicAcls": true,
+                "BlockPublicPolicy": true,
+                "IgnorePublicAcls": true,
+                "RestrictPublicBuckets": true
+            },
+            "VersioningConfiguration": {
+                "Status": "Enabled"
+            }
+        },
+        "Type": "AWS::S3::Bucket",
+        "DeletionPolicy": "Retain"
+    },
+    "TestBucketWithRolesPolicy": {
+        "Properties": {
+            "Bucket": {
+                "Ref": "TestBucketWithRoles"
+            },
+            "PolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Deny",
+                        "Principal": {
+                            "AWS": "*"
+                        },
+                        "Action": "s3:*",
+                        "Resource": "arn:aws:s3:::test-bucket-with-roles/*",
+                        "Condition": {
+                            "Bool": {
+                                "aws:SecureTransport": "false"
+                            }
+                        }
+                    },
+                    {
+                        "Effect": "Deny",
+                        "Principal": {
+                            "AWS": "*"
+                        },
+                        "Action": "s3:PutObject",
+                        "Resource": "arn:aws:s3:::test-bucket-with-roles/*",
+                        "Condition": {
+                            "StringNotEquals": {
+                                "s3:x-amz-server-side-encryption": "AES256"
+                            }
+                        }
+                    },
+                    {
+                        "Effect": "Deny",
+                        "Principal": {
+                            "AWS": "*"
+                        },
+                        "Action": "s3:PutObject",
+                        "Resource": "arn:aws:s3:::test-bucket-with-roles/*",
+                        "Condition": {
+                            "Null": {
+                                "s3:x-amz-server-side-encryption": "true"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "Type": "AWS::S3::BucketPolicy"
+    },
+    "TestBucketRestorePolicy": {
+        "Properties": {
+            "Description": "Grants read access permissions to test-bucket-with-roles bucket",
+            "ManagedPolicyName": "TestBucketRestorePolicy",
+            "PolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": [
+                            "s3:GetObject"
+                        ],
+                        "Resource": "arn:aws:s3:::test-bucket-with-roles/*"
+                    },
+                    {
+                        "Effect": "Allow",
+                        "Action": [
+                            "s3:ListBucket"
+                        ],
+                        "Resource": "arn:aws:s3:::test-bucket-with-roles"
+                    }
+                ]
+            },
+            "Path": "/test/"
+        },
+        "Type": "AWS::IAM::ManagedPolicy"
+    },
+    "TestBucketRestoreRole": {
+        "Properties": {
+            "RoleName": "TestBucketRestoreRole",
+            "Description": "Role with read access to test-bucket-with-roles bucket.",
+            "ManagedPolicyArns": [
+                {
+                    "Ref": "TestBucketRestorePolicy"
+                }
+            ],
+            "AssumeRolePolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": "sts:AssumeRole",
+                        "Principal": {
+                            "Service": [
+                                "lambda.amazonaws.com"
+                            ]
+                        }
+                    },
+                    {
+                        "Effect": "Allow",
+                        "Action": "sts:AssumeRole",
+                        "Principal": {
+                            "AWS": [
+                                "arn:aws:iam::34567891011:root"
+                            ]
+                        }
+                    },
+                    {
+                        "Effect": "Allow",
+                        "Action": [
+                            "sts:AssumeRole",
+                            "sts:SetSourceIdentity"
+                        ],
+                        "Principal": {
+                            "AWS": [
+                                "arn:aws:iam::456789101112:root"
+                            ]
+                        }
+                    }
+                ]
+            },
+            "Tags": [
+                {
+                    "Key": "Name",
+                    "Value": "TestBucketRestoreRole"
+                }
+            ],
+            "Path": "/test/"
+        },
+        "Type": "AWS::IAM::Role"
+    },
+    "TestBucketPushPolicy": {
+        "Properties": {
+            "Description": "Grants write access permissions to test-bucket-with-roles bucket",
+            "ManagedPolicyName": "TestBucketPushPolicy",
+            "PolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": [
+                            "s3:PutObject",
+                            "s3:DeleteObject"
+                        ],
+                        "Resource": "arn:aws:s3:::test-bucket-with-roles/*"
+                    }
+                ]
+            },
+            "Path": "/test/"
+        },
+        "Type": "AWS::IAM::ManagedPolicy"
+    },
+    "TestBucketPushRole": {
+        "Properties": {
+            "RoleName": "TestBucketPushRole",
+            "Description": "Role with read and write access to test-bucket-with-roles bucket.",
+            "ManagedPolicyArns": [
+                {
+                    "Ref": "TestBucketPushPolicy"
+                },
+                {
+                    "Ref": "TestBucketRestorePolicy"
+                }
+            ],
+            "AssumeRolePolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": "sts:AssumeRole",
+                        "Principal": {
+                            "AWS": [
+                                "arn:aws:iam::987654321:root"
+                            ]
+                        }
+                    },
+                    {
+                        "Effect": "Allow",
+                        "Action": "sts:AssumeRole",
+                        "Principal": {
+                            "Service": [
+                                "lambda.amazonaws.com"
+                            ]
+                        }
+                    }
+                ]
+            },
+            "Tags": [
+                {
+                    "Key": "Name",
+                    "Value": "TestBucketPushRole"
+                }
+            ],
+            "Path": "/test/"
+        },
+        "Type": "AWS::IAM::Role"
+    }
+}

--- a/tests/tests_e3_aws/troposphere/s3/s3_test.py
+++ b/tests/tests_e3_aws/troposphere/s3/s3_test.py
@@ -1,13 +1,15 @@
 """Provide S3 construct tests."""
 import json
 import os
-
+import pytest
 from e3.aws.troposphere.s3.bucket import Bucket, EncryptionAlgorithm
 from e3.aws.troposphere.s3 import BucketWithRoles
 from e3.aws.troposphere import Stack
 from e3.aws.troposphere.awslambda import Py38Function
 from e3.aws.troposphere.sns import Topic
 from e3.aws.troposphere.sqs import Queue
+from e3.aws.troposphere.iam.policy_statement import Trust
+from e3.aws.troposphere.iam.policy_document import PolicyDocument
 
 
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -145,3 +147,51 @@ def test_bucket_notification_string_arns(stack: Stack) -> None:
         expected_template = json.load(fd)
 
     assert stack.export()["Resources"] == expected_template
+
+
+def test_bucket_with_roles_and_trust_policies(stack: Stack) -> None:
+    """Test BucketWithRoles with trust policies."""
+    bucket = BucketWithRoles(
+        name="test-bucket-with-roles",
+        trust_policy=[Trust(services=["lambda"])],
+        iam_names_prefix="TestBucket",
+        iam_read_root_name="Restore",
+        iam_write_root_name="Push",
+        iam_path="/test/",
+        write_trusted_accounts=["987654321"],
+        read_trust_policy=PolicyDocument(
+            statements=[
+                Trust(
+                    accounts=["34567891011"],
+                ),
+                Trust(
+                    accounts=["456789101112"],
+                    actions=["sts:AssumeRole", "sts:SetSourceIdentity"],
+                ),
+            ]
+        ),
+    )
+    stack.add(bucket)
+
+    with open(os.path.join(TEST_DIR, "bucket-with-roles-trusted-policies.json")) as fd:
+        expected_template = json.load(fd)
+
+    assert stack.export()["Resources"] == expected_template
+
+
+def test_bucket_with_roles_and_trust_policies_error(stack: Stack) -> None:
+    """Test BucketWithRoles with trust policies raises error."""
+    with pytest.raises(AttributeError) as exc:
+        BucketWithRoles(
+            name="test-bucket-with-roles",
+            trusted_accounts=["123456789"],
+            trust_policy=[Trust(services=["lambda"])],
+            iam_names_prefix="TestBucket",
+            iam_read_root_name="Restore",
+            iam_write_root_name="Push",
+            iam_path="/test/",
+        )
+    assert (
+        str(exc.value) == "You cannot set 'trust_policy' and "
+        "'trusted_accounts' at the same time , please use one or the other."
+    )


### PR DESCRIPTION
Add new trust_policy parameters that will allow for further customization of the trust policies of the read and write roles.
* trust_policy: this parameter add a trust policy to both read and write roles
* read_trust_policy: adds a trust policy only to the read role
* write_trust_policy: adds a trust role only to the write role