### PR TITLE
Bump ci to python3.11 by default

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.9", "3.10"]
+        python: ["3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v2
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-           python-version: 3.9
+           python-version: 3.11
       - name: Install Tox and any other packages
         run: |
              python -m pip install -U pip
@@ -51,5 +51,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-           python-version: 3.9
+           python-version: 3.11
       - uses: pre-commit/action@v2.0.0

--- a/src/e3/aws/troposphere/iam/policy_statement.py
+++ b/src/e3/aws/troposphere/iam/policy_statement.py
@@ -67,7 +67,7 @@ class Allow(PolicyStatement):
         :param principal: principal affected by the policy
         :param condition: conditions for when the policy is in effect
         """
-        return super().__init__(
+        super().__init__(
             action=action,
             effect="Allow",
             resource=resource,

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39-cov
+envlist = py311-cov
 
 [testenv]
 deps =


### PR DESCRIPTION
Bump all ci jobs to python 3.11 by default and run builds only on python 3.11 and python 3.12