### PR TITLE
Fix tests using moto following moto v5 release

### DIFF
--- a/tests/tests_e3_aws/dynamodb/main_test.py
+++ b/tests/tests_e3_aws/dynamodb/main_test.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING
 import pytest
-from moto import mock_sts, mock_dynamodb
+from moto import mock_aws
 from botocore.exceptions import ClientError
 import boto3
 from e3.aws.dynamodb import DynamoDB
@@ -30,7 +30,7 @@ def assert_customers(client: DynamoDB, customers: list[dict[str, Any]]) -> None:
 @pytest.fixture
 def client() -> Iterable[DynamoDB]:
     """Return a client for the DynamoDB."""
-    with mock_sts(), mock_dynamodb():
+    with mock_aws():
         client = boto3.resource("dynamodb", region_name="us-east-1")
         client.create_table(
             TableName=TABLE_NAME,

--- a/tests/tests_e3_aws/s3/main_test.py
+++ b/tests/tests_e3_aws/s3/main_test.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING
 import pytest
-from moto import mock_sts, mock_s3
+from moto import mock_aws
 import boto3
 from e3.aws.s3 import S3, KeyExistsError, KeyNotFoundError
 
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 @pytest.fixture
 def client() -> Iterable[S3]:
     """Return a client for S3."""
-    with mock_sts(), mock_s3():
+    with mock_aws():
         client = boto3.client("s3", region_name="us-east-1")
         client.create_bucket(Bucket="test")
 


### PR DESCRIPTION
The moto v5 release has introduced a new all service-specific decorator, mock_aws, that replaces all the old ones. This commit updates all tests that use moto to use this new decorator.