### PR TITLE
Add support for keyword arguments to Bucket Construct

### DIFF
--- a/src/e3/aws/troposphere/s3/bucket.py
+++ b/src/e3/aws/troposphere/s3/bucket.py
@@ -20,6 +20,8 @@ if TYPE_CHECKING:
     from e3.aws.troposphere import Stack
     from e3.aws.troposphere.iam.policy_statement import ConditionType
 
+    from typing import Any
+
 
 class EncryptionAlgorithm(Enum):
     """Provide an Enum to describe encryption algorithms."""
@@ -40,6 +42,7 @@ class Bucket(Construct):
             EncryptionAlgorithm | None
         ) = EncryptionAlgorithm.AES256,
         authorized_encryptions: list[EncryptionAlgorithm] | None = None,
+        **bucket_kwargs: Any,
     ):
         """Initialize a bucket.
 
@@ -50,6 +53,7 @@ class Bucket(Construct):
         :param default_bucket_encryption: type of the default bucket encryption.
         :param authorized_encryptions: types of the server side encryptions
             to authorize.
+        :param bucket_kwargs: keyword arguments to pass to the bucket constructor
         """
         self.name = name
         self.enable_versioning = enable_versioning
@@ -65,6 +69,7 @@ class Bucket(Construct):
         self.topic_configurations: list[tuple[dict[str, str], Topic | None, str]] = []
         self.queue_configurations: list[tuple[dict[str, str], Queue | None, str]] = []
         self.depends_on: list[str] = []
+        self.bucket_kwargs = bucket_kwargs
 
         # Add minimal policy statements
         self.policy_statements = [
@@ -293,6 +298,7 @@ class Bucket(Construct):
             if val:
                 attr[key] = val
 
+        attr |= self.bucket_kwargs
         return [
             s3.Bucket(name_to_id(self.name), **attr),
             s3.BucketPolicy(

--- a/tests/tests_e3_aws/troposphere/s3/bucket_with_object_lock_kwargs.json
+++ b/tests/tests_e3_aws/troposphere/s3/bucket_with_object_lock_kwargs.json
@@ -1,0 +1,80 @@
+{
+    "TestBucket": {
+        "Properties": {
+            "BucketName": "test-bucket",
+            "BucketEncryption": {
+                "ServerSideEncryptionConfiguration": [
+                    {
+                        "ServerSideEncryptionByDefault": {
+                            "SSEAlgorithm": "AES256"
+                        }
+                    }
+                ]
+            },
+            "PublicAccessBlockConfiguration": {
+                "BlockPublicAcls": true,
+                "BlockPublicPolicy": true,
+                "IgnorePublicAcls": true,
+                "RestrictPublicBuckets": true
+            },
+            "VersioningConfiguration": {
+                "Status": "Enabled"
+            },
+            "ObjectLockEnabled": true
+        },
+        "Type": "AWS::S3::Bucket",
+        "DeletionPolicy": "Retain"
+    },
+    "TestBucketPolicy": {
+        "Properties": {
+            "Bucket": {
+                "Ref": "TestBucket"
+            },
+            "PolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Deny",
+                        "Principal": {
+                            "AWS": "*"
+                        },
+                        "Action": "s3:*",
+                        "Resource": "arn:aws:s3:::test-bucket/*",
+                        "Condition": {
+                            "Bool": {
+                                "aws:SecureTransport": "false"
+                            }
+                        }
+                    },
+                    {
+                        "Effect": "Deny",
+                        "Principal": {
+                            "AWS": "*"
+                        },
+                        "Action": "s3:PutObject",
+                        "Resource": "arn:aws:s3:::test-bucket/*",
+                        "Condition": {
+                            "StringNotEquals": {
+                                "s3:x-amz-server-side-encryption": "AES256"
+                            }
+                        }
+                    },
+                    {
+                        "Effect": "Deny",
+                        "Principal": {
+                            "AWS": "*"
+                        },
+                        "Action": "s3:PutObject",
+                        "Resource": "arn:aws:s3:::test-bucket/*",
+                        "Condition": {
+                            "Null": {
+                                "s3:x-amz-server-side-encryption": "true"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "Type": "AWS::S3::BucketPolicy"
+    }
+}

--- a/tests/tests_e3_aws/troposphere/s3/s3_test.py
+++ b/tests/tests_e3_aws/troposphere/s3/s3_test.py
@@ -124,6 +124,20 @@ def test_bucket_multi_encryption(stack: Stack) -> None:
     assert stack.export()["Resources"] == expected_template
 
 
+def test_bucket_with_kwargs(stack: Stack) -> None:
+    """Test passing ObjectLockEnabled as kwargs."""
+    bucket = Bucket(
+        name="test-bucket",
+        ObjectLockEnabled=True,
+    )
+    stack.add(bucket)
+
+    with open(os.path.join(TEST_DIR, "bucket_with_object_lock_kwargs.json")) as fd:
+        expected_template = json.load(fd)
+
+    assert stack.export()["Resources"] == expected_template
+
+
 def test_bucket_notification_string_arns(stack: Stack) -> None:
     """Test bucket notification with string arns instead of objects."""
     bucket = Bucket(name="test-bucket")


### PR DESCRIPTION
This is convenient to support all CloudFormation arguments without explictly listing them.