### PR TITLE
Add a method to subscribe SQS Queue to SNS Topic

### DIFF
--- a/src/e3/aws/troposphere/sns/__init__.py
+++ b/src/e3/aws/troposphere/sns/__init__.py
@@ -42,8 +42,10 @@ class Topic(Construct):
             "Endpoint": function.arn,
             "Protocol": "lambda",
             "TopicArn": self.arn,
-            "DeliveryPolicy": delivery_policy,
         }
+
+        if delivery_policy:
+            sub_params.update({"DeliveryPolicy": delivery_policy})
 
         self.optional_resources.extend(
             [

--- a/tests/tests_e3_aws/troposphere/sqs/sqs_test.py
+++ b/tests/tests_e3_aws/troposphere/sqs/sqs_test.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from e3.aws.troposphere import Stack
+from e3.aws.troposphere.sqs import Queue
+
+EXPECTED_QUEUE_DEFAULT_TEMPLATE = {
+    "Myqueue": {
+        "Properties": {"QueueName": "myqueue", "VisibilityTimeout": 30},
+        "Type": "AWS::SQS::Queue",
+    }
+}
+
+
+EXPECTED_QUEUE_TEMPLATE = {
+    "Myqueue": {
+        "Properties": {
+            "ContentBasedDeduplication": True,
+            "FifoQueue": True,
+            "QueueName": "myqueue.fifo",
+            "RedrivePolicy": {
+                "deadLetterTargetArn": {"Fn::GetAtt": ["Somedlqname", "Arn"]},
+                "maxReceiveCount": "3",
+            },
+            "VisibilityTimeout": 10,
+        },
+        "Type": "AWS::SQS::Queue",
+    }
+}
+
+
+EXPECTED_SQS_SUBSCRIPTION_TEMPLATE = {
+    "Myqueue": {
+        "Properties": {"QueueName": "myqueue", "VisibilityTimeout": 30},
+        "Type": "AWS::SQS::Queue",
+    },
+    "MyqueuePolicySub": {
+        "Properties": {
+            "PolicyDocument": {
+                "Statement": [
+                    {
+                        "Action": "sqs:SendMessage",
+                        "Condition": {"ArnLike": {"aws:SourceArn": "some_topic_arn"}},
+                        "Effect": "Allow",
+                        "Principal": {"Service": "sns.amazonaws.com"},
+                        "Resource": {"Fn::GetAtt": ["Myqueue", "Arn"]},
+                    }
+                ],
+                "Version": "2012-10-17",
+            },
+            "Queues": [{"Ref": "Myqueue"}],
+        },
+        "Type": "AWS::SQS::QueuePolicy",
+    },
+    "MyqueueSub": {
+        "Properties": {
+            "Endpoint": {"Fn::GetAtt": ["Myqueue", "Arn"]},
+            "Protocol": "sqs",
+            "TopicArn": "some_topic_arn",
+        },
+        "Type": "AWS::SNS::Subscription",
+    },
+}
+
+
+def test_queue_default(stack: Stack) -> None:
+    """Test Queue default creation."""
+    stack.add(Queue(name="myqueue"))
+    assert stack.export()["Resources"] == EXPECTED_QUEUE_DEFAULT_TEMPLATE
+
+
+def test_queue(stack: Stack) -> None:
+    """Test Queue creation."""
+    stack.add(
+        Queue(
+            name="myqueue", fifo=True, visibility_timeout=10, dlq_name="some_dlq_name"
+        )
+    )
+    assert stack.export()["Resources"] == EXPECTED_QUEUE_TEMPLATE
+
+
+def test_subscribe_to_sns_topic(stack: Stack) -> None:
+    """Test sqs subscription to sns topic."""
+    queue = Queue(name="myqueue")
+    queue.subscribe_to_sns_topic("some_topic_arn")
+
+    stack.add(queue)
+
+    assert stack.export()["Resources"] == EXPECTED_SQS_SUBSCRIPTION_TEMPLATE


### PR DESCRIPTION
- Create new method for `e3.aws.troposphere.sqs.Queue` to generate template with SNS Topic subscription
- Add tests for  `e3.aws.troposphere.sqs.Queue` class
- Fix TypeError in `e3.aws.troposphere.sns.Topic.add_lambda_subscription` if `delivery_policy` is None